### PR TITLE
refactor: update terminal and package output channel names from "Roo …

### DIFF
--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -16,8 +16,8 @@ import { DEFAULT_WRITE_DELAY_MS } from "@siid-code/types"
 
 import { DecorationController } from "./DecorationController"
 
-export const DIFF_VIEW_URI_SCHEME = "cline-diff"
-export const DIFF_VIEW_LABEL_CHANGES = "Original ↔ Roo's Changes"
+export const DIFF_VIEW_URI_SCHEME = "siid-diff"
+export const DIFF_VIEW_LABEL_CHANGES = "Original ↔ Siid's Changes"
 
 // TODO: https://github.com/cline/cline/pull/3354
 export class DiffViewProvider {

--- a/src/integrations/terminal/Terminal.ts
+++ b/src/integrations/terminal/Terminal.ts
@@ -17,7 +17,7 @@ export class Terminal extends BaseTerminal {
 
 		const env = Terminal.getEnv()
 		const iconPath = new vscode.ThemeIcon("rocket")
-		this.terminal = terminal ?? vscode.window.createTerminal({ cwd, name: "Roo Code", iconPath, env })
+		this.terminal = terminal ?? vscode.window.createTerminal({ cwd, name: "Siid Code", iconPath, env })
 
 		if (Terminal.getTerminalZdotdir()) {
 			ShellIntegrationManager.terminalTmpDirs.set(id, env.ZDOTDIR)

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -644,7 +644,7 @@ export class McpHub {
 		try {
 			const client = new Client(
 				{
-					name: "Roo Code",
+					name: "Siid Code",
 					version: this.providerRef.deref()?.context.extension?.packageJSON?.version ?? "1.0.0",
 				},
 				{

--- a/src/shared/package.ts
+++ b/src/shared/package.ts
@@ -14,6 +14,6 @@ export const Package = {
 	publisher,
 	name: process.env.PKG_NAME || name,
 	version: process.env.PKG_VERSION || version,
-	outputChannel: process.env.PKG_OUTPUT_CHANNEL || "Roo-Code",
+	outputChannel: process.env.PKG_OUTPUT_CHANNEL || "Siid-Code",
 	sha: process.env.PKG_SHA,
 } as const


### PR DESCRIPTION
This pr solves issue: #43 and #44 
This pull request updates the branding across the codebase from "Roo Code" to "Siid Code". The changes ensure that all user-facing labels, environment variables, and internal identifiers consistently use the new product name.

Branding updates:

* Changed the terminal name from `"Roo Code"` to `"Siid Code"` in the `Terminal` class (`src/integrations/terminal/Terminal.ts`).
* Updated the client name from `"Roo Code"` to `"Siid Code"` in the `McpHub` service (`src/services/mcp/McpHub.ts`).
* Changed the output channel default from `"Roo-Code"` to `"Siid-Code"` in the `Package` constant (`src/shared/package.ts`).
* Updated the diff view URI scheme and label from `"cline-diff"` and `"Original ↔ Roo's Changes"` to `"siid-diff"` and `"Original ↔ Siid's Changes"` in the `DiffViewProvider` (`src/integrations/editor/DiffViewProvider.ts`).