### PR TITLE
Retrieve Salesforce Metadata Tool

### DIFF
--- a/.roo/rules-Salesforce_Agent/assignment-rules.md
+++ b/.roo/rules-Salesforce_Agent/assignment-rules.md
@@ -1,9 +1,32 @@
 # Salesforce Assignment Rules — Full Workflow (with Queue Creation)
 
-This workflow automates creation and deployment of Assignment Rules in Salesforce using the Salesforce CLI.  
+This workflow automates creation and deployment of Assignment Rules in Salesforce using the Salesforce CLI.
 It supports creating a new Queue dynamically if it does not already exist.
 
 All commands use the `sf` CLI.
+
+## 0. Check Existing Assignment Rules (RECOMMENDED FIRST STEP)
+
+Before creating new assignment rules, retrieve existing assignment rules from the Salesforce org:
+
+- **Use the <retrieve_sf_metadata> tool with metadata_type "AssignmentRules" to retrieve all assignment rules**
+- This will retrieve all assignment rules from all objects in the org
+- **IMPORTANT: Check if there is an ACTIVE assignment rule on the target object**
+- After retrieval, read the assignment rules file for the object: `force-app/main/default/assignmentRules/<ObjectApiName>.assignmentRules-meta.xml`
+- Look for any `<assignmentRule>` with `<active>true</active>` tag
+- If an active assignment rule exists:
+    - Inform the user: "An active assignment rule already exists for [ObjectName]"
+    - Show the existing rule details (rule name, assigned to)
+    - Ask: "Do you want to deactivate the existing rule and create a new active rule?"
+    - **If user says YES:**
+        - Set the existing rule's `<active>` tag to `false`
+        - Create the new rule with `<active>true</active>`
+    - **If user says NO:**
+        - Create the new rule with `<active>false</active>` (inactive)
+        - Inform the user they can activate it later from Salesforce Setup
+- If no active assignment rule exists:
+    - Continue with creating the new rule as active
+- **Note:** Only one assignment rule can be active per object at a time
 
 ## 1. Prompt: Gather Minimal Inputs
 

--- a/.roo/rules-Salesforce_Agent/custom-field.md
+++ b/.roo/rules-Salesforce_Agent/custom-field.md
@@ -9,11 +9,13 @@ This mode assists the AI model in creating **Salesforce custom fields** by gener
 ### **1. Check Target Object** (IMPORTANT!)
 
 - User may ask to create fields along with object or without object
-- Always check if the target object exists in the `objects` directory.
-- (IMPORTANT!)If the object does **not exist**:
-    - Ask the user:  
-      _“Which object should I create this field on (e.g., Account, Contact, or Custom Object)?”_
-    - If it’s a custom object, confirm its API name ends with `__c` (e.g., `Invoice__c`).
+- Always check if the target object exists:
+    - First, check locally in the `objects` directory (force-app/main/default/objects/)
+    - Also use the <retrieve_sf_metadata> tool with metadata_type "CustomObject" and metadata_name "<ObjectApiName>" to check if the object exists in the Salesforce org
+- (IMPORTANT!)If the object does **not exist** (either locally or in the org):
+    - Ask the user:
+      _"Which object should I create this field on (e.g., Account, Contact, or Custom Object)?"_
+    - If it's a custom object, confirm its API name ends with `__c` (e.g., `Invoice__c`).
 - If the object exists, continue with field creation.
 
 ### **2. Folder and File Placement**
@@ -119,15 +121,15 @@ Target Object
 
 - After creation of field assign read permission to those fields for system administrator profile.
 - Fetch the system administrator profile and assign read permission like this
-    <?xml version="1.0" encoding="UTF-8"?>
-    <Profile xmlns="http://soap.sforce.com/2006/04/metadata">
-        <fieldPermissions>
-            <editable>false</editable>
-            <field>Project__c.Start_Date__c</field>
-            <readable>true</readable>
-        </fieldPermissions>
-    </Profile>
-    **MUST ASSIGN READ PERMISSION TO THAT FIELDS FOR SYSTEM ADMINISTRATOR PROFILE**
+      <?xml version="1.0" encoding="UTF-8"?>
+      <Profile xmlns="http://soap.sforce.com/2006/04/metadata">
+          <fieldPermissions>
+              <editable>false</editable>
+              <field>Project__c.Start_Date__c</field>
+              <readable>true</readable>
+          </fieldPermissions>
+      </Profile>
+      **MUST ASSIGN READ PERMISSION TO THAT FIELDS FOR SYSTEM ADMINISTRATOR PROFILE**
 
 **7. Validation with User**
 Before generating final XML, confirm:

--- a/.roo/rules-Salesforce_Agent/custom-object.md
+++ b/.roo/rules-Salesforce_Agent/custom-object.md
@@ -10,11 +10,13 @@ This mode assists the AI model in creating Salesforce objects by generating the 
 
 ## Check Existing Object
 
-- Before creating a new object, check if the object already exists in the objects directory.
-- If the object already exists:
+- Before creating a new object, check if the object already exists:
+    - First, check locally in the objects directory (force-app/main/default/objects/)
+    - Also use the <retrieve_sf_metadata> tool with metadata_type "CustomObject" and metadata_name "<ObjectApiName>" to check if the object exists in the Salesforce org
+- If the object already exists (either locally or in the org):
     - Inform the user that the object is already present.
-    - Ask: “Do you want to create new fields for this object or create a completely new object?”
-- If the object does not exist, continue with the rules below.
+    - Ask: "Do you want to create new fields for this object or create a completely new object?"
+- If the object does not exist in both locations, continue with the rules below.
 
 ## Folder Creation
 

--- a/.roo/rules-Salesforce_Agent/object-permission.md
+++ b/.roo/rules-Salesforce_Agent/object-permission.md
@@ -1,7 +1,41 @@
 **Salesforce Custom Profile Creation**
 
-- When user ask to assign objects permission a profile, always first run this command `sf project retrieve start --metadata "Profile:ProfileName"` to retrive the the profile data.
-  \*\*Note: you have to retrieve profile every time to ensure that we have latest data.
+- When user asks to assign object permissions to a profile, always first retrieve the profile data following this flow:
+
+1. List all available Profile metadata from the Salesforce org:
+
+    ```bash
+    sf org list metadata -m Profile --json > profiles.json
+    ```
+
+    **Notes:**
+
+    - This command produces a JSON list of available Profile metadata in the target org.
+    - Saving the output to `profiles.json` ensures you have an up-to-date authoritative mapping between the friendly names and the backend metadata names.
+
+2. Inspect `profiles.json` to understand the available profiles and their exact API/backend names.
+
+3. Map the user-provided profile name to the exact `fullName` in `profiles.json`:
+
+    - Use an exact match when possible. If the user uses a friendly/display name (for example, "System Administrator"), implement a mapping or a small fuzzy-match routine that compares the user input against `fullName` and `fileName` values from `profiles.json` and returns the closest match.
+
+    - Example mapping logic (shell/Node pseudocode):
+
+        ```bash
+        # extract fullNames into a plain list
+        jq -r '.result[].fullName' profiles.json > profile-names.txt
+
+        # do case-insensitive search or fuzzy match to find the best candidate
+        # (implement in Node.js or a small script to return the closest fullName)
+        ```
+
+4. Once you have the correct backend `fullName` for the profile, retrieve the profile metadata file:
+
+    - Use the <retrieve_sf_metadata> tool with metadata_type "Profile" and metadata_name "<FULL_NAME>" to retrieve the specific profile
+    - Replace `<FULL_NAME>` with the exact backend name you mapped from `profiles.json`.
+
+\*\*Note: you have to retrieve profile every time to ensure that we have latest data.
+
 - Then first make list make list of objects with permission which user want to assign permission to which profile
   \*\*Note: This is structure of adding object permissions
   <objectPermissions>

--- a/.roo/rules-Salesforce_Agent/profile.md
+++ b/.roo/rules-Salesforce_Agent/profile.md
@@ -34,11 +34,8 @@ When the user asks to "create a profile" or to "create from <source profile>", f
 
 4. Once you have the correct backend `fullName` for the source profile, retrieve the profile metadata file into your local source tree (if not already retrieved).
 
-    ```bash
-    sf project retrieve start --metadata "Profile:<FULL_NAME>"
-    ```
-
-    Replace `<FULL_NAME>` with the exact backend name you mapped from `profiles.json`.
+    - Use the <retrieve_sf_metadata> tool with metadata_type "Profile" and metadata_name "<FULL_NAME>" to retrieve the specific profile
+    - Replace `<FULL_NAME>` with the exact backend name you mapped from `profiles.json`.
 
 5. Copy or clone the retrieved profile file to create the new profile XML file. Use relative paths and keep the metadata filename consistent with the new profile `fullName` you plan to deploy.
 

--- a/.roo/rules-Salesforce_Agent/record-types.md
+++ b/.roo/rules-Salesforce_Agent/record-types.md
@@ -5,6 +5,9 @@ Always follow this step-by-step process when creating a Salesforce Record Type. 
 1. Initial Prompt
 
     - When the user asks to create a record type, do NOT create or deploy anything yet.
+    - Use the <retrieve_sf_metadata> tool with metadata_type "CustomObject" and metadata_name "<ObjectName>" to retrieve the specific object
+    - Check if record types already exist in the recordTypes/ subfolder under force-app/main/default/objects/<ObjectName>/recordTypes/
+    - If existing record types are found, display them to the user for awareness
     - Confirm these details with the user:
         - Object API Name
         - Record Type Label

--- a/.roo/rules-Salesforce_Agent/role-creation.md
+++ b/.roo/rules-Salesforce_Agent/role-creation.md
@@ -8,9 +8,13 @@ This mode assists the AI model in creating and managing Salesforce roles by gene
 
 # Strict Rules for Salesforce Role Creation
 
-## Check Existing Role
+## Check Existing Role(Important!!)
 
-- Before creating a new role, check if the role already exists in the roles directory.
+- Before creating a new role, retrieve all existing roles from the Salesforce org.
+- **Use the <retrieve_sf_metadata> tool with metadata_type "Role" to get all roles**
+- This will retrieve all roles from the Salesforce org and save them to your local project directory.
+- **Note:** Ensure you are connected to a default org.
+- Check the retrieved roles to see if the user's requested role already exists.
 - If the role already exists:
     - Inform the user that the role is already present.
     - Ask: "Do you want to update this role or create a different role?"
@@ -18,9 +22,18 @@ This mode assists the AI model in creating and managing Salesforce roles by gene
 
 ## Fetch Existing Roles (When Needed)
 
-- If the user wants to create a role as a **parent** or **child** of an existing role, first fetch the existing role metadata:
+- If the user wants to create a role as a **parent** or **child** of an existing role, first fetch the existing role metadata using the retrieve_sf_metadata tool:
+
+```xml
+<retrieve_sf_metadata>
+<metadata_type>Role</metadata_type>
+<metadata_name>RoleDeveloperName</metadata_name>
+</retrieve_sf_metadata>
+```
+
+- Replace `RoleDeveloperName` with the actual role developer name (e.g., CEO, Sales_Manager).
+- **Alternative CLI command (if tool is unavailable):**
   `sf project retrieve start --metadata Role:<RoleDeveloperName>`
-- Replace `<RoleDeveloperName>` with the actual role developer name (e.g., CEO, Sales_Manager).
 
 ## File and Folder Creation
 
@@ -106,7 +119,13 @@ This mode assists the AI model in creating and managing Salesforce roles by gene
     ### Scenario 3: Creating a Parent Role (with Child)
     - If creating a role that will be the **parent of an existing role**:
         - First, create the new parent role.
-        - Then, fetch the existing child role: `sf project retrieve start --metadata Role:<ChildRoleDeveloperName>`
+        - Then, fetch the existing child role using retrieve_sf_metadata:
+        ```xml
+        <retrieve_sf_metadata>
+        <metadata_type>Role</metadata_type>
+        <metadata_name>ChildRoleDeveloperName</metadata_name>
+        </retrieve_sf_metadata>
+        ```
         - Update the child role XML to include the `<parentRole>` tag pointing to the new parent: `<parentRole>Parent_Role_Developer_Name</parentRole>`
         - Deploy both the new parent role and the updated child role.
     - **Deployment Commands:**
@@ -117,8 +136,13 @@ This mode assists the AI model in creating and managing Salesforce roles by gene
     ### Scenario 4: Creating a Middle Role (Both Parent and Child)
     - If creating a role that is **both a child of one role AND a parent of another role**:
         - First, create the new role with the `<parentRole>` tag pointing to its parent: `<parentRole>Parent_Role_Developer_Name</parentRole>`
-        - Then, fetch the role that will be its child:
-        `sf project retrieve start --metadata Role:<ChildRoleDeveloperName>`
+        - Then, fetch the role that will be its child using retrieve_sf_metadata:
+        ```xml
+        <retrieve_sf_metadata>
+        <metadata_type>Role</metadata_type>
+        <metadata_name>ChildRoleDeveloperName</metadata_name>
+        </retrieve_sf_metadata>
+        ```
         - Update the child role XML to set the new role as its parent by adding or modifying the `<parentRole>` tag: `<parentRole>New_Middle_Role_Developer_Name</parentRole>`
         - Deploy all affected roles in the correct order:
         1. Deploy the new middle role first

--- a/.roo/rules-Salesforce_Agent/validation-rules.md
+++ b/.roo/rules-Salesforce_Agent/validation-rules.md
@@ -13,7 +13,19 @@
     Gather Basic Information
     When a user asks to create a validation rule, collect:
     Object name (e.g., "Account", "Opportunity", "CustomObject__c")
-    Validation formula - the condition that should block the save
+    User's requirement/prompt - understand what the user wants to validate
+
+    Check existing validation rules on the object FIRST:
+    - Use the <retrieve_sf_metadata> tool with metadata_type "CustomObject" and metadata_name "<ObjectName>" to retrieve the object
+    - Check the validationRules/ subfolder under force-app/main/default/objects/<ObjectName>/validationRules/ for existing validation rules
+    - If validation rules exist, review them and compare with the user's requirement/prompt:
+        - Check if any existing validation rule already implements similar logic or validates the same condition the user is requesting
+        - If a similar validation rule exists, inform the user and ask:
+          "A similar validation rule already exists: [RuleName] with formula: [Formula]. Do you want to:
+          1. Update the existing rule
+          2. Create a new rule anyway
+          3. Cancel"
+    - If no similar rules exist, proceed with collecting the validation formula from the user and creating the new validation rule
 
 ## Step 2:
 

--- a/.roo/rules-code/apex-guide.md
+++ b/.roo/rules-code/apex-guide.md
@@ -38,9 +38,71 @@
 
 ---
 
-## Creation of XML: (! IMPORTANT)
+## Creation of XML: (!!**IMPORTANT**)
 
 - After creation of apex class immediatly create it's XML file too WITHOUT ASKING.
+
+## User-Provided Guidelines Priority (**HIGHEST PRIORITY**)
+
+- **When the user provides code or project guidelines in a BRD (Business Requirement Document), you MUST prioritize those guidelines above all else.**
+- User-provided guidelines have the **HIGHEST PRIORITY** and override any default patterns or best practices mentioned in this guide.
+- If there is a conflict between user guidelines and this reference guide, always follow the user's guidelines.
+- Examples of user guidelines include:
+    - Naming conventions specific to the project
+    - Code structure and architecture patterns
+    - Error handling approaches
+    - Testing strategies
+    - Documentation standards
+    - Deployment processes
+- Always acknowledge and confirm user-provided guidelines before proceeding with implementation.
+
+## (!!**IMPORTANT**)Retrieving Apex Classes
+
+**CRITICAL RULE: ALWAYS RETRIEVE BEFORE CREATING OR MODIFYING ANY APEX CLASS**
+
+Before creating or modifying Apex classes, you MUST ALWAYS check existing classes in the Salesforce org first:
+
+### Directory Location
+
+**Apex classes are stored in:** `force-app/main/default/classes/`
+
+- Each Apex class has two files:
+    - `ClassName.cls` (the Apex class file)
+    - `ClassName.cls-meta.xml` (the metadata XML file)
+
+### (!!**IMPORTANT**)Retrieve All Apex Classes
+
+- **MANDATORY FIRST STEP**: Use the <retrieve_sf_metadata> tool with metadata_type "ApexClass" to retrieve all Apex classes from the org
+- This retrieves all classes to the `force-app/main/default/classes/` directory
+- **ALWAYS DO THIS** when starting any Apex-related task to understand what classes exist in the org
+- **DO NOT skip this step** - you must check what already exists before creating new classes
+
+### (!!**IMPORTANT**)Retrieve Specific Apex Classes
+
+- Use the <retrieve_sf_metadata> tool with metadata_type "ApexClass" and metadata_name "<ClassName>" to retrieve a specific class
+- Replace <ClassName> with the actual class name without the .cls extension (e.g., "AccountService", "MyController", "OpportunityTriggerHandler")
+- The tool retrieves files to `force-app/main/default/classes/`
+- Use this when you need to view or modify a specific class
+
+### Sync Latest Code
+
+- **MANDATORY**: Before modifying any Apex class, always retrieve the latest version using the tool to ensure you have the most current code
+- This prevents conflicts and ensures you're working with the latest version from the org
+- Always sync before making changes to existing classes
+
+### When to Use Retrieval (MANDATORY CHECKLIST)
+
+✅ **ALWAYS retrieve at the start** of any Apex-related task to understand existing code
+✅ **ALWAYS retrieve before creating** a new class to check if a similar class already exists
+✅ **ALWAYS retrieve before modifying** a class to get the latest version
+✅ When syncing local code with org code
+✅ When analyzing or refactoring existing Apex code
+
+### ❌ NEVER DO THIS
+
+❌ **NEVER create an Apex class file directly without first using the retrieve tool**
+❌ **NEVER assume a class doesn't exist** - always retrieve and check first
+❌ **NEVER modify a class without retrieving** the latest version first
 
 ## Language Fundamentals
 
@@ -2319,7 +2381,7 @@ for(Account acc : accountList) {
 
 ---
 
-### 9. Dry run and Deployment:(! IMPORTANT)
+### 9. (**!! IMPORTANT**)Dry run and Deployment:
 
 After creation of all required apex classes and LWC components then first do dry run on apex using this command:
 `sf project deploy start --dry-run --source-dir force-app/main/default/classes/<classname.cls>`
@@ -2328,8 +2390,18 @@ Replace <classname.cls> with the actual classes.
 - If got any errors after dry run solve them.
 - After successful dry run of apex classes then immediatly proceed with deloyment of apex classes.
   `sf project deploy start --source-dir force-app/main/default/objects/<classname.cls>`
-- Replace <classname.cls> with the all classes that are created comma separated.
-- Before Going for LWC first dry-run and deploy Apex Classes.(!IMPORTANT)
+- Replace <classname.cls> with the all classes that are created like below format for multiple apex classes deployment:
+    # Deploy multiple specific Apex classes in order
+    ```
+    sf project deploy start --dry-run --source-dir force-app/main/default/objects/MyCustomObject__c --source-dir force-app/main/default/classes/HelperClass.cls --source-dir force-app/main/default/classes/MainService.cls --source-dir force-app/main/default/triggers/AccountTrigger.trigger
+    ```
+- (**!IMPORTANT**)Before Going for LWC first dry-run and deploy Apex Classes.
+
+Deploy only the metadata files and component bundles that were created or modified by the AI — do NOT deploy the entire metadata folder. Deploying the whole folder can introduce unrelated dependencies and cause avoidable deployment failures.
+
+Deployment workflow you should follow every time:
+
+- Verify dependencies: if LWC calls Apex controllers, ensure those Apex classes are deployed.
 
 ## Quick Reference: Common Patterns
 

--- a/.roo/rules-code/lwc-guide.md
+++ b/.roo/rules-code/lwc-guide.md
@@ -4,6 +4,76 @@
 
 ---
 
+## (**!IMPORTANT**)Retrieving Lightning Web Components
+
+**CRITICAL RULE: ALWAYS RETRIEVE BEFORE CREATING OR MODIFYING ANY LWC COMPONENT**
+
+Before creating or modifying Lightning Web Components, you MUST ALWAYS check existing components in the Salesforce org first:
+
+### Directory Location
+
+**Lightning Web Components are stored in:** `force-app/main/default/lwc/`
+
+- Each LWC component has its own folder with multiple files:
+    - `componentName/` (folder in camelCase)
+        - `componentName.js` (JavaScript controller - required)
+        - `componentName.html` (HTML template - optional)
+        - `componentName.css` (CSS styles - optional)
+        - `componentName.js-meta.xml` (metadata configuration - required)
+
+### (**!IMPORTANT**)Retrieve All Lightning Web Components
+
+- **MANDATORY FIRST STEP**: Use the <retrieve_sf_metadata> tool with metadata_type "LightningComponentBundle" to retrieve all LWC components from the org
+- This retrieves all LWC components to the `force-app/main/default/lwc/` directory
+- **ALWAYS DO THIS** when starting any LWC-related task to understand what components exist in the org
+- **DO NOT skip this step** - you must check what already exists before creating new components
+
+### (**!IMPORTANT**)Retrieve Specific Lightning Web Components
+
+- Use the <retrieve_sf_metadata> tool with metadata_type "LightningComponentBundle" and metadata_name "<ComponentName>" to retrieve a specific component
+- Replace <ComponentName> with the actual component folder name in camelCase (e.g., "myComponent", "accountList", "opportunityCard")
+- This retrieves the entire component bundle including .js, .html, .css, and .js-meta.xml files to `force-app/main/default/lwc/<ComponentName>/`
+- Use this when you need to view or modify a specific component
+
+### Sync Latest Code
+
+- **MANDATORY**: Before modifying any LWC component, always retrieve the latest version using the tool to ensure you have the most current code
+- This prevents conflicts and ensures you're working with the latest version from the org
+- Always sync before making changes to existing components
+
+### When to Use Retrieval (MANDATORY CHECKLIST)
+
+✅ **ALWAYS retrieve at the start** of any LWC-related task to understand existing components
+✅ **ALWAYS retrieve before creating** a new component to check if a similar component already exists
+✅ **ALWAYS retrieve before modifying** a component to get the latest version
+✅ When syncing local code with org code
+✅ When analyzing or refactoring existing LWC components
+✅ When working with component composition (checking parent/child components)
+
+### ❌ NEVER DO THIS
+
+❌ **NEVER create an LWC component folder/files directly without first using the retrieve tool**
+❌ **NEVER assume a component doesn't exist** - always retrieve and check first
+❌ **NEVER modify a component without retrieving** the latest version first
+
+---
+
+## User-Provided Guidelines Priority (HIGHEST PRIORITY)
+
+- **When the user provides code or project guidelines in a BRD (Business Requirement Document), you MUST prioritize those guidelines above all else.**
+- User-provided guidelines have the **HIGHEST PRIORITY** and override any default patterns or best practices mentioned in this guide.
+- If there is a conflict between user guidelines and this reference guide, always follow the user's guidelines.
+- Examples of user guidelines include:
+    - Naming conventions specific to the project
+    - Component structure and architecture patterns
+    - Event handling approaches
+    - Data management strategies
+    - Styling and design system standards
+    - Testing and documentation requirements
+- Always acknowledge and confirm user-provided guidelines before proceeding with implementation.
+
+---
+
 ## Core Concepts
 
 ### What LWC Is
@@ -673,10 +743,10 @@ Salesforce provides base components built on SLDS:
 
 ---
 
-### Dry run and Deployment:(! IMPORTANT)
+### Dry run and Deployment: (!!**IMPORTANT - selective deployment only**)
 
-After creation of all required apex classes and LWC components then first do dry run on LWC using this command:(After completion of apex deployment)
--Before doing Dry-run of LWC make sure you deployed required Apex classes (!IMPORTANT)
+After creation of all required apex classes and LWC components then first do dry run on LWC using this command:(**!!Important- After completion of apex deployment**)
+-(**!IMPORTANT**)Before doing Dry-run of LWC make sure you deployed required Apex classes
 `sf project deploy start --dry-run --source-dir force-app/main/default/lwc/<componentname>`
 Replace <componentname> with the actual classes.
 
@@ -684,6 +754,12 @@ Replace <componentname> with the actual classes.
 - After successful dry run then proceed with deloyment process.
   `sf project deploy start --source-dir force-app/main/default/objects/<componentname>`
 - Replace <componentname> with the all components that are created comma separated.
+
+Deploy only the metadata files and component bundles that were created or modified by the AI — do NOT deploy the entire metadata folder. Deploying the whole folder can introduce unrelated dependencies and cause avoidable deployment failures.
+
+Deployment workflow you should follow every time:
+
+- Verify dependencies: if LWC calls Apex controllers, ensure those Apex classes are deployed.
 
 ## Development Tools
 

--- a/packages/types/src/tool.ts
+++ b/packages/types/src/tool.ts
@@ -34,6 +34,7 @@ export const toolNames = [
 	"fetch_instructions",
 	"codebase_search",
 	"update_todo_list",
+	"retrieve_sf_metadata",
 ] as const
 
 export const toolNamesSchema = z.enum(toolNames)

--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -33,6 +33,7 @@ import { Task } from "../task/Task"
 import { codebaseSearchTool } from "../tools/codebaseSearchTool"
 import { experiments, EXPERIMENT_IDS } from "../../shared/experiments"
 import { applyDiffToolLegacy } from "../tools/applyDiffTool"
+import { retrieveSfMetadataTool } from "../tools/retrieveSfMetadataTool"
 
 /**
  * Processes and presents assistant message content to the user interface.
@@ -213,6 +214,8 @@ export async function presentAssistantMessage(cline: Task) {
 						const modeName = getModeBySlug(mode, customModes)?.name ?? mode
 						return `[${block.name} in ${modeName} mode: '${message}']`
 					}
+					case "retrieve_sf_metadata":
+						return `[${block.name} for '${block.params.metadata_type}'${block.params.metadata_name ? `: ${block.params.metadata_name}` : " (all)"}]`
 				}
 			}
 
@@ -524,6 +527,16 @@ export async function presentAssistantMessage(cline: Task) {
 						removeClosingTag,
 						toolDescription,
 						askFinishSubTaskApproval,
+					)
+					break
+				case "retrieve_sf_metadata":
+					await retrieveSfMetadataTool(
+						cline,
+						block,
+						askApproval,
+						handleError,
+						pushToolResult,
+						removeClosingTag,
 					)
 					break
 			}

--- a/src/core/prompts/tools/index.ts
+++ b/src/core/prompts/tools/index.ts
@@ -23,6 +23,7 @@ import { getSwitchModeDescription } from "./switch-mode"
 import { getNewTaskDescription } from "./new-task"
 import { getCodebaseSearchDescription } from "./codebase-search"
 import { getUpdateTodoListDescription } from "./update-todo-list"
+import { getRetrieveSfMetadataDescription } from "./retrieve-sf-metadata"
 import { CodeIndexManager } from "../../../services/code-index/manager"
 
 // Map of tool names to their description functions
@@ -47,6 +48,7 @@ const toolDescriptionMap: Record<string, (args: ToolArgs) => string | undefined>
 	apply_diff: (args) =>
 		args.diffStrategy ? args.diffStrategy.getToolDescription({ cwd: args.cwd, toolOptions: args.toolOptions }) : "",
 	update_todo_list: (args) => getUpdateTodoListDescription(args),
+	retrieve_sf_metadata: (args) => getRetrieveSfMetadataDescription(args),
 }
 
 export function getToolDescriptionsForMode(

--- a/src/core/prompts/tools/retrieve-sf-metadata.ts
+++ b/src/core/prompts/tools/retrieve-sf-metadata.ts
@@ -1,0 +1,125 @@
+import { ToolArgs } from "./types"
+
+export function getRetrieveSfMetadataDescription(args: ToolArgs): string {
+	return `## retrieve_sf_metadata
+Description: Dynamically retrieves metadata from a Salesforce org using Salesforce CLI commands. This tool intelligently analyzes the metadata type and name to determine which SF CLI command to execute. It can retrieve full metadata of a type or specific named metadata components.
+
+Supported Metadata Types and Commands:
+- ApexClass: Retrieves Apex class source code
+- ApexTrigger: Retrieves Apex trigger source code
+- CustomObject: Retrieves custom object definition
+- CustomField: Retrieves custom field definition (use format: ObjectName.FieldName)
+- LightningComponentBundle: Retrieves Lightning Web Component bundle
+- AuraDefinitionBundle: Retrieves Aura component bundle
+- FlexiPage: Retrieves Lightning page definition
+- Flow: Retrieves Flow definition
+- PermissionSet: Retrieves permission set definition
+- Profile: Retrieves profile definition
+- Layout: Retrieves page layout definition
+- ApexPage: Retrieves Visualforce page
+- ApexComponent: Retrieves Visualforce component
+- StaticResource: Retrieves static resource
+- CustomTab: Retrieves custom tab definition
+- CustomApplication: Retrieves custom application definition
+- StandardValueSet: Retrieves standard value set (picklist values)
+- GlobalValueSet: Retrieves global value set
+- RecordType: Retrieves record type definition (use format: ObjectName.RecordTypeName)
+- ValidationRule: Retrieves validation rule (use format: ObjectName.ValidationRuleName)
+- Role: Retrieves role hierarchy definition
+- AssignmentRule: Retrieves assignment rule (use format: ObjectName.RuleName, e.g., Case.Standard_Case_Assignment or Lead.Lead_Assignment)
+- AssignmentRules: Retrieves all assignment rules for an object (use format: ObjectName, e.g., Case or Lead)
+- PathAssistant: Retrieves Sales Path / Path Assistant definition
+- PathAssistantSettings: Retrieves Path Assistant settings
+
+Parameters:
+- metadata_type: (required) The type of Salesforce metadata to retrieve (e.g., ApexClass, CustomObject, LightningComponentBundle, StandardValueSet, Layout, etc.)
+- metadata_name: (optional) The API name of the specific metadata component to retrieve. If not provided, retrieves a list of all metadata of that type.
+  - For CustomField: Use format ObjectName.FieldName (e.g., Account.Industry, Invoice__c.Customer_Type__c)
+  - For RecordType: Use format ObjectName.RecordTypeName (e.g., Account.Partner)
+  - For ValidationRule: Use format ObjectName.ValidationRuleName (e.g., Account.Email_Required)
+  - For Layout: Use format ObjectName-LayoutName (e.g., Account-Account Layout)
+  - For AssignmentRule: Use format ObjectName.RuleName (e.g., Case.Standard_Case_Assignment)
+  - For AssignmentRules: Use the object name (e.g., Case, Lead)
+  - For PathAssistant: Use the path name (e.g., Opportunity_Path)
+
+Usage:
+<retrieve_sf_metadata>
+<metadata_type>MetadataType</metadata_type>
+<metadata_name>MetadataApiName</metadata_name>
+</retrieve_sf_metadata>
+
+Example: Retrieve a specific Apex class
+<retrieve_sf_metadata>
+<metadata_type>ApexClass</metadata_type>
+<metadata_name>AccountHandler</metadata_name>
+</retrieve_sf_metadata>
+
+Example: List all Apex classes in the org
+<retrieve_sf_metadata>
+<metadata_type>ApexClass</metadata_type>
+</retrieve_sf_metadata>
+
+Example: Retrieve a specific custom object
+<retrieve_sf_metadata>
+<metadata_type>CustomObject</metadata_type>
+<metadata_name>Invoice__c</metadata_name>
+</retrieve_sf_metadata>
+
+Example: Retrieve a custom field
+<retrieve_sf_metadata>
+<metadata_type>CustomField</metadata_type>
+<metadata_name>Account.Industry</metadata_name>
+</retrieve_sf_metadata>
+
+Example: Retrieve a Lightning Web Component
+<retrieve_sf_metadata>
+<metadata_type>LightningComponentBundle</metadata_type>
+<metadata_name>myComponent</metadata_name>
+</retrieve_sf_metadata>
+
+Example: Retrieve a Standard Value Set (picklist)
+<retrieve_sf_metadata>
+<metadata_type>StandardValueSet</metadata_type>
+<metadata_name>Industry</metadata_name>
+</retrieve_sf_metadata>
+
+Example: Retrieve a page layout
+<retrieve_sf_metadata>
+<metadata_type>Layout</metadata_type>
+<metadata_name>Account-Account Layout</metadata_name>
+</retrieve_sf_metadata>
+
+Example: Retrieve a specific role
+<retrieve_sf_metadata>
+<metadata_type>Role</metadata_type>
+<metadata_name>CEO</metadata_name>
+</retrieve_sf_metadata>
+
+Example: List all roles in the org
+<retrieve_sf_metadata>
+<metadata_type>Role</metadata_type>
+</retrieve_sf_metadata>
+
+Example: Retrieve Case assignment rules
+<retrieve_sf_metadata>
+<metadata_type>AssignmentRules</metadata_type>
+<metadata_name>Case</metadata_name>
+</retrieve_sf_metadata>
+
+Example: Retrieve a specific assignment rule
+<retrieve_sf_metadata>
+<metadata_type>AssignmentRule</metadata_type>
+<metadata_name>Lead.Standard_Lead_Assignment</metadata_name>
+</retrieve_sf_metadata>
+
+Example: Retrieve a Sales Path
+<retrieve_sf_metadata>
+<metadata_type>PathAssistant</metadata_type>
+<metadata_name>Opportunity_Path</metadata_name>
+</retrieve_sf_metadata>
+
+Example: List all Sales Paths
+<retrieve_sf_metadata>
+<metadata_type>PathAssistant</metadata_type>
+</retrieve_sf_metadata>`
+}

--- a/src/core/tools/retrieveSfMetadataTool.ts
+++ b/src/core/tools/retrieveSfMetadataTool.ts
@@ -1,0 +1,352 @@
+import * as path from "path"
+import { execSync } from "child_process"
+
+import { Task } from "../task/Task"
+import { ToolUse, AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "../../shared/tools"
+import { formatResponse } from "../prompts/responses"
+
+/**
+ * Metadata type configuration for SF CLI commands
+ */
+interface MetadataTypeConfig {
+	// The metadata type name as used by SF CLI
+	cliType: string
+	// Whether this type supports listing all components
+	supportsListing: boolean
+	// Custom command builder if needed
+	customCommand?: (metadataName: string, cwd: string) => string
+	// Description for error messages
+	description: string
+}
+
+/**
+ * Configuration for supported Salesforce metadata types
+ */
+const METADATA_TYPE_CONFIG: Record<string, MetadataTypeConfig> = {
+	ApexClass: {
+		cliType: "ApexClass",
+		supportsListing: true,
+		description: "Apex Class",
+	},
+	ApexTrigger: {
+		cliType: "ApexTrigger",
+		supportsListing: true,
+		description: "Apex Trigger",
+	},
+	CustomObject: {
+		cliType: "CustomObject",
+		supportsListing: true,
+		description: "Custom Object",
+	},
+	CustomField: {
+		cliType: "CustomField",
+		supportsListing: true,
+		description: "Custom Field",
+	},
+	LightningComponentBundle: {
+		cliType: "LightningComponentBundle",
+		supportsListing: true,
+		description: "Lightning Web Component",
+	},
+	AuraDefinitionBundle: {
+		cliType: "AuraDefinitionBundle",
+		supportsListing: true,
+		description: "Aura Component",
+	},
+	FlexiPage: {
+		cliType: "FlexiPage",
+		supportsListing: true,
+		description: "Lightning Page",
+	},
+	Flow: {
+		cliType: "Flow",
+		supportsListing: true,
+		description: "Flow",
+	},
+	PermissionSet: {
+		cliType: "PermissionSet",
+		supportsListing: true,
+		description: "Permission Set",
+	},
+	Profile: {
+		cliType: "Profile",
+		supportsListing: true,
+		description: "Profile",
+	},
+	Layout: {
+		cliType: "Layout",
+		supportsListing: true,
+		description: "Page Layout",
+	},
+	ApexPage: {
+		cliType: "ApexPage",
+		supportsListing: true,
+		description: "Visualforce Page",
+	},
+	ApexComponent: {
+		cliType: "ApexComponent",
+		supportsListing: true,
+		description: "Visualforce Component",
+	},
+	StaticResource: {
+		cliType: "StaticResource",
+		supportsListing: true,
+		description: "Static Resource",
+	},
+	CustomTab: {
+		cliType: "CustomTab",
+		supportsListing: true,
+		description: "Custom Tab",
+	},
+	CustomApplication: {
+		cliType: "CustomApplication",
+		supportsListing: true,
+		description: "Custom Application",
+	},
+	StandardValueSet: {
+		cliType: "StandardValueSet",
+		supportsListing: true,
+		description: "Standard Value Set",
+	},
+	GlobalValueSet: {
+		cliType: "GlobalValueSet",
+		supportsListing: true,
+		description: "Global Value Set",
+	},
+	RecordType: {
+		cliType: "RecordType",
+		supportsListing: true,
+		description: "Record Type",
+	},
+	ValidationRule: {
+		cliType: "ValidationRule",
+		supportsListing: true,
+		description: "Validation Rule",
+	},
+	Role: {
+		cliType: "Role",
+		supportsListing: true,
+		description: "Role",
+	},
+	AssignmentRule: {
+		cliType: "AssignmentRule",
+		supportsListing: true,
+		description: "Assignment Rule",
+	},
+	AssignmentRules: {
+		cliType: "AssignmentRules",
+		supportsListing: true,
+		description: "Assignment Rules",
+	},
+	PathAssistant: {
+		cliType: "PathAssistant",
+		supportsListing: true,
+		description: "Path Assistant (Sales Path)",
+	},
+	PathAssistantSettings: {
+		cliType: "PathAssistantSettings",
+		supportsListing: true,
+		description: "Path Assistant Settings",
+	},
+}
+
+/**
+ * Build the SF CLI command based on metadata type and name
+ */
+function buildSfCommand(metadataType: string, metadataName: string | undefined, cwd: string): string {
+	const config = METADATA_TYPE_CONFIG[metadataType]
+
+	if (!config) {
+		throw new Error(
+			`Unsupported metadata type: ${metadataType}. Supported types: ${Object.keys(METADATA_TYPE_CONFIG).join(", ")}`,
+		)
+	}
+
+	// If custom command builder exists, use it
+	if (config.customCommand && metadataName) {
+		return config.customCommand(metadataName, cwd)
+	}
+
+	// If no metadata name provided, list all metadata of that type
+	if (!metadataName) {
+		if (!config.supportsListing) {
+			throw new Error(
+				`Metadata type ${metadataType} does not support listing all components. Please provide a metadata_name.`,
+			)
+		}
+		return `sf project retrieve start --metadata "${config.cliType}:*" --json`
+	}
+
+	// Retrieve specific metadata component
+	return `sf project retrieve start --metadata "${config.cliType}:${metadataName}" --json`
+}
+
+/**
+ * Parse and format the SF CLI output
+ */
+function formatSfOutput(output: string, metadataType: string, metadataName: string | undefined): string {
+	try {
+		const jsonOutput = JSON.parse(output)
+
+		if (jsonOutput.status === 0) {
+			const result = jsonOutput.result
+
+			if (!metadataName) {
+				// Listing mode - show retrieved files
+				const files = result?.files || []
+				if (files.length === 0) {
+					return `No ${metadataType} metadata found in the org.`
+				}
+
+				const fileList = files.map((f: any) => `  - ${f.fullName || f.fileName}`).join("\n")
+
+				return `Successfully retrieved ${files.length} ${metadataType} component(s):\n${fileList}\n\nFiles have been retrieved to your local project directory.`
+			}
+
+			// Specific component retrieval
+			const files = result?.files || []
+			if (files.length === 0) {
+				return `${metadataType} '${metadataName}' was retrieved but no files were found. The component may not exist in the org.`
+			}
+
+			const fileDetails = files
+				.map((f: any) => {
+					const filePath = f.filePath || f.fileName || "Unknown path | details: " + JSON.stringify(f)
+					const state = f.state || "Retrieved"
+					return `  - ${filePath} (${state})`
+				})
+				.join("\n")
+
+			return `Successfully retrieved ${metadataType} '${metadataName}':\n${fileDetails}\n\nThe metadata has been saved to your local project directory. You can now read the files to inspect the metadata content.`
+		} else {
+			// Error in SF CLI response
+			const errorMessage = jsonOutput.message || jsonOutput.result?.message || "Unknown error occurred"
+			const errorName = jsonOutput.name || "SfError"
+			return `SF CLI Error (${errorName}): ${errorMessage}`
+		}
+	} catch (parseError) {
+		// If JSON parsing fails, return raw output
+		if (output.includes("ERROR") || output.includes("error")) {
+			return `SF CLI Error:\n${output}`
+		}
+		return `SF CLI Output:\n${output}`
+	}
+}
+
+export async function retrieveSfMetadataTool(
+	cline: Task,
+	block: ToolUse,
+	askApproval: AskApproval,
+	handleError: HandleError,
+	pushToolResult: PushToolResult,
+	removeClosingTag: RemoveClosingTag,
+) {
+	const metadataType: string | undefined = block.params.metadata_type
+	const metadataName: string | undefined = block.params.metadata_name
+
+	try {
+		if (block.partial) {
+			// Show partial state while streaming
+			const partialMessage = removeClosingTag("metadata_type", metadataType)
+			await cline
+				.ask(
+					"tool",
+					JSON.stringify({
+						tool: "retrieveSfMetadata",
+						metadataType: partialMessage,
+						metadataName: removeClosingTag("metadata_name", metadataName),
+					}),
+					block.partial,
+				)
+				.catch(() => {})
+			return
+		}
+
+		// Validate required parameters
+		if (!metadataType) {
+			cline.consecutiveMistakeCount++
+			cline.recordToolError("retrieve_sf_metadata")
+			pushToolResult(await cline.sayAndCreateMissingParamError("retrieve_sf_metadata", "metadata_type"))
+			return
+		}
+
+		// Reset mistake count on valid input
+		cline.consecutiveMistakeCount = 0
+
+		// Build the SF CLI command
+		let command: string
+		try {
+			command = buildSfCommand(metadataType, metadataName, cline.cwd)
+		} catch (error) {
+			pushToolResult(formatResponse.toolError(error.message))
+			return
+		}
+
+		// Create approval message
+		const approvalMessage = metadataName
+			? `Retrieve ${metadataType}: ${metadataName}`
+			: `List all ${metadataType} metadata`
+
+		// Ask for approval
+		const toolMessage = JSON.stringify({
+			tool: "retrieveSfMetadata",
+			metadataType,
+			metadataName: metadataName || "(all)",
+			command,
+		})
+
+		const didApprove = await askApproval("tool", toolMessage)
+
+		if (!didApprove) {
+			return
+		}
+
+		// Execute the SF CLI command
+		try {
+			// Execute command synchronously with timeout
+			const output = execSync(command, {
+				cwd: cline.cwd,
+				encoding: "utf-8",
+				timeout: 120000, // 2 minute timeout
+				maxBuffer: 10 * 1024 * 1024, // 10MB buffer
+				stdio: ["pipe", "pipe", "pipe"],
+			})
+
+			// Format and return the result
+			const formattedResult = formatSfOutput(output, metadataType, metadataName)
+			pushToolResult(formattedResult)
+		} catch (execError: any) {
+			// Handle execution errors
+			let errorMessage = "Failed to execute SF CLI command"
+
+			if (execError.killed) {
+				errorMessage = "Command timed out after 2 minutes"
+			} else if (execError.stderr) {
+				errorMessage = execError.stderr
+			} else if (execError.stdout) {
+				// Sometimes SF CLI returns error info in stdout with non-zero exit
+				const formattedResult = formatSfOutput(execError.stdout, metadataType, metadataName)
+				pushToolResult(formattedResult)
+				return
+			} else if (execError.message) {
+				errorMessage = execError.message
+			}
+
+			// Check for common SF CLI issues
+			if (errorMessage.includes("command not found") || errorMessage.includes("'sf' is not recognized")) {
+				errorMessage =
+					"Salesforce CLI (sf) is not installed or not in PATH. Please install it from https://developer.salesforce.com/tools/salesforcecli"
+			} else if (errorMessage.includes("No default org set") || errorMessage.includes("No default username")) {
+				errorMessage =
+					"No default Salesforce org is set. Please run 'sf org login web' or 'sf config set target-org <username>' to set a default org."
+			} else if (errorMessage.includes("ENOENT")) {
+				errorMessage =
+					"Salesforce CLI (sf) is not installed. Please install it from https://developer.salesforce.com/tools/salesforcecli"
+			}
+
+			pushToolResult(formatResponse.toolError(`SF CLI Error: ${errorMessage}`))
+		}
+	} catch (error) {
+		await handleError("retrieving Salesforce metadata", error)
+	}
+}

--- a/src/shared/tools.ts
+++ b/src/shared/tools.ts
@@ -65,6 +65,8 @@ export const toolParamNames = [
 	"query",
 	"args",
 	"todos",
+	"metadata_type",
+	"metadata_name",
 ] as const
 
 export type ToolParamName = (typeof toolParamNames)[number]
@@ -158,6 +160,11 @@ export interface NewTaskToolUse extends ToolUse {
 	params: Partial<Pick<Record<ToolParamName, string>, "mode" | "message">>
 }
 
+export interface RetrieveSfMetadataToolUse extends ToolUse {
+	name: "retrieve_sf_metadata"
+	params: Partial<Pick<Record<ToolParamName, string>, "metadata_type" | "metadata_name">>
+}
+
 export interface SearchAndReplaceToolUse extends ToolUse {
 	name: "search_and_replace"
 	params: Required<Pick<Record<ToolParamName, string>, "path" | "search" | "replace">> &
@@ -190,6 +197,7 @@ export const TOOL_DISPLAY_NAMES: Record<ToolName, string> = {
 	search_and_replace: "search and replace",
 	codebase_search: "codebase search",
 	update_todo_list: "update todo list",
+	retrieve_sf_metadata: "retrieve salesforce metadata",
 } as const
 
 // Define available tool groups.
@@ -202,6 +210,7 @@ export const TOOL_GROUPS: Record<ToolGroup, ToolGroupConfig> = {
 			"list_files",
 			"list_code_definition_names",
 			"codebase_search",
+			"retrieve_sf_metadata",
 		],
 	},
 	edit: {


### PR DESCRIPTION
feat: Implement retrieve_sf_metadata tool for dynamic Salesforce metadata retrieval

- Added retrieve_sf_metadata tool to fetch various Salesforce metadata types including Apex classes, custom objects, Lightning components, and more.
- Updated documentation across multiple files to reflect the new tool usage and its importance in the metadata retrieval process.
- Enhanced existing rules for Salesforce paths, profiles, record types, roles, validation rules, Apex classes, and Lightning Web Components to incorporate the new retrieval tool.
- Ensured that all relevant metadata types are supported and provided clear examples for usage in the documentation.