### PR TITLE
feat: implement development bypass for Firebase auth and enhance provider settings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,6 +68,8 @@ export async function activate(context: vscode.ExtensionContext) {
 	const activationStartTime = Date.now()
 
 	extensionContext = context
+	// Make context available globally for utilities like firebaseHelper
+	;(global as any).__rooCodeExtensionContext = context
 	outputChannel = vscode.window.createOutputChannel(Package.outputChannel)
 	context.subscriptions.push(outputChannel)
 	outputChannel.appendLine(`${Package.name} extension activated - ${JSON.stringify(Package)}`)

--- a/src/utils/firebaseHelper.ts
+++ b/src/utils/firebaseHelper.ts
@@ -84,6 +84,17 @@ export async function isAuthenticated(outputChannel?: vscode.OutputChannel): Pro
 
 	try {
 		log("Checking authentication status")
+
+		// Check for dev bypass mode first
+		const context = (global as any).__rooCodeExtensionContext as vscode.ExtensionContext | undefined
+		if (context) {
+			const devBypassActive = context.globalState.get<boolean>("devBypassActive")
+			if (devBypassActive) {
+				log("Dev bypass mode active - returning authenticated")
+				return true
+			}
+		}
+
 		const api = await getFirebaseAPI(outputChannel)
 		if (!api) {
 			log("Firebase API not available for authentication check")

--- a/webview-ui/src/components/chat/ApiConfigSelector.tsx
+++ b/webview-ui/src/components/chat/ApiConfigSelector.tsx
@@ -20,6 +20,7 @@ interface ApiConfigSelectorProps {
 	pinnedApiConfigs?: Record<string, boolean>
 	togglePinnedApiConfig: (id: string) => void
 	useFreeModels?: boolean
+	developerMode?: boolean
 }
 
 export const ApiConfigSelector = ({
@@ -34,6 +35,7 @@ export const ApiConfigSelector = ({
 	pinnedApiConfigs,
 	togglePinnedApiConfig,
 	useFreeModels = false,
+	developerMode = false,
 }: ApiConfigSelectorProps) => {
 	const { t } = useAppTranslation()
 	const [open, setOpen] = useState(false)
@@ -42,20 +44,31 @@ export const ApiConfigSelector = ({
 
 	// If a mode is provided, only show the mode-specific basic/medium/advanced configs
 	// If useFreeModels is true, only show configs ending with -free
+	// If developerMode is enabled, always include the default config
 	const modeFilteredList = useMemo(() => {
 		let filtered = listApiConfigMeta
 
 		if (mode) {
 			const allowedNames = [`${mode}-basic-free`, `${mode}-medium`, `${mode}-advanced`]
+
+			// If developer mode is enabled, also allow the default config
+			if (developerMode) {
+				allowedNames.push("default")
+			}
+
 			filtered = filtered.filter((c) => allowedNames.includes(c.name ?? ""))
 		}
 
 		if (useFreeModels) {
-			filtered = filtered.filter((c) => (c.name ?? "").endsWith("-free"))
+			// Filter for free configs, but keep default if developer mode is enabled
+			filtered = filtered.filter((c) => {
+				const name = c.name ?? ""
+				return name.endsWith("-free") || (developerMode && name === "default")
+			})
 		}
 
 		return filtered
-	}, [listApiConfigMeta, mode, useFreeModels])
+	}, [listApiConfigMeta, mode, useFreeModels, developerMode])
 
 	// Create searchable items for fuzzy search
 	const searchableItems = useMemo(() => {

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -90,6 +90,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			clineMessages,
 			commands,
 			useFreeModels,
+			developerMode,
 		} = useExtensionState() // Find the ID and display text for the currently selected API configuration
 		const { currentConfigId, displayName } = useMemo(() => {
 			const currentConfig = listApiConfigMeta?.find((config) => config.name === currentApiConfigName)
@@ -948,6 +949,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							pinnedApiConfigs={pinnedApiConfigs}
 							togglePinnedApiConfig={togglePinnedApiConfig}
 							useFreeModels={useFreeModels}
+							developerMode={developerMode}
 						/>
 					</div>
 				</div>

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -79,7 +79,6 @@ export interface SettingsViewRef {
 }
 
 const sectionNames = [
-	"providers",
 	"autoApprove",
 	"browser",
 	"checkpoints",
@@ -90,6 +89,7 @@ const sectionNames = [
 	"experimental",
 	"language",
 	"about",
+	"providers",
 ] as const
 
 type SectionName = (typeof sectionNames)[number]
@@ -416,21 +416,28 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 		}
 	}, [])
 
-	const sections: { id: SectionName; icon: LucideIcon }[] = useMemo(
-		() => [
-			{ id: "autoApprove", icon: CheckCheck },
-			{ id: "browser", icon: SquareMousePointer },
-			{ id: "checkpoints", icon: GitBranch },
-			{ id: "notifications", icon: Bell },
-			{ id: "contextManagement", icon: Database },
-			{ id: "terminal", icon: SquareTerminal },
-			{ id: "prompts", icon: MessageSquare },
-			{ id: "experimental", icon: FlaskConical },
-			{ id: "language", icon: Globe },
-			{ id: "about", icon: Info },
-		],
-		[], // No dependencies needed now
-	)
+	const isDeveloperMode = (cachedState as any)?.developerMode
+	const sections: { id: SectionName; icon: LucideIcon }[] = useMemo(() => {
+		const baseSections = [
+			{ id: "autoApprove" as SectionName, icon: CheckCheck },
+			{ id: "browser" as SectionName, icon: SquareMousePointer },
+			{ id: "checkpoints" as SectionName, icon: GitBranch },
+			{ id: "notifications" as SectionName, icon: Bell },
+			{ id: "contextManagement" as SectionName, icon: Database },
+			{ id: "terminal" as SectionName, icon: SquareTerminal },
+			{ id: "prompts" as SectionName, icon: MessageSquare },
+			{ id: "experimental" as SectionName, icon: FlaskConical },
+			{ id: "language" as SectionName, icon: Globe },
+			{ id: "about" as SectionName, icon: Info },
+		]
+
+		// Add providers tab only when developer mode is enabled
+		if (isDeveloperMode) {
+			baseSections.unshift({ id: "providers" as SectionName, icon: Webhook })
+		}
+
+		return baseSections
+	}, [isDeveloperMode])
 
 	// Update target section logic to set active tab
 	useEffect(() => {


### PR DESCRIPTION
This pull request introduces a development bypass mode for authentication, allowing developers to manually provide an API key and simulate authentication without Firebase. It also improves how provider configs are listed and displayed, and enhances the webview UI to support developer mode features, including conditional visibility of the "providers" tab and the default config in selectors.

**Development bypass authentication and logout:**

* Added manual authentication and logout handlers to `registerCommands.ts`, allowing developers to input an API key for bypassing Firebase during development. The bypass state and API key are stored in global state, and the UI is updated accordingly.
* The authentication check in `firebaseHelper.ts` now returns authenticated if development bypass mode is active, using the global extension context.
* The extension context is made globally available for utilities by setting it on the global object in `extension.ts`.
* Provider API key fetching in `ProviderSettingsManager.ts` prioritizes the development bypass API key if present, ensuring all configs use it during development mode.

**Provider config listing and selection:**

* The provider config listing now includes the "default" config, rather than excluding it, in `ProviderSettingsManager.ts`.
* In the chat UI, the API config selector always includes the "default" config when developer mode is enabled, and filters configs accordingly. [[1]](diffhunk://#diff-36c41984b6ac37eae05ebf0a53141aff18987fb4b0df7d1acb738b999e3f118eR23) [[2]](diffhunk://#diff-36c41984b6ac37eae05ebf0a53141aff18987fb4b0df7d1acb738b999e3f118eR38) [[3]](diffhunk://#diff-36c41984b6ac37eae05ebf0a53141aff18987fb4b0df7d1acb738b999e3f118eR47-R71) [[4]](diffhunk://#diff-5cdc3e037adb830799fedad9f1e51eba2fddf6b81552dfb4ee28786a22f730bcR93) [[5]](diffhunk://#diff-5cdc3e037adb830799fedad9f1e51eba2fddf6b81552dfb4ee28786a22f730bcR952)

**Webview UI improvements for developer mode:**

* The providers tab in settings is now conditionally visible only when developer mode is enabled, and its position/order is updated. [[1]](diffhunk://#diff-5e117d9dbc386d8e091bc6d42429785d0f3138330c09eab8d7fb1837c91be5dfL82) [[2]](diffhunk://#diff-5e117d9dbc386d8e091bc6d42429785d0f3138330c09eab8d7fb1837c91be5dfR92) [[3]](diffhunk://#diff-5e117d9dbc386d8e091bc6d42429785d0f3138330c09eab8d7fb1837c91be5dfL419-R440)