### PR TITLE
feat: preserve XML entities when writing XML files Agent

### DIFF
--- a/src/core/tools/__tests__/writeToFileTool.spec.ts
+++ b/src/core/tools/__tests__/writeToFileTool.spec.ts
@@ -304,6 +304,17 @@ describe("writeToFileTool", () => {
 			expect(mockedUnescapeHtmlEntities).not.toHaveBeenCalled()
 		})
 
+		it("preserves XML entities when writing XML files", async () => {
+			mockCline.api.getModel.mockReturnValue({ id: "gpt-4" })
+
+			await executeWriteFileTool({
+				path: "force-app/main/default/objects/Account/validationRules/AnnualRevenue.validationRule-meta.xml",
+				content: "&lt;ValidationRule&gt;",
+			})
+
+			expect(mockedUnescapeHtmlEntities).not.toHaveBeenCalled()
+		})
+
 		it("strips line numbers from numbered content", async () => {
 			const contentWithLineNumbers = "1 | line one\n2 | line two"
 			mockedEveryLineHasLineNumbers.mockReturnValue(true)

--- a/src/core/tools/writeToFileTool.ts
+++ b/src/core/tools/writeToFileTool.ts
@@ -27,6 +27,10 @@ function logWriteToolDebug(event: string, payload: Record<string, unknown>) {
 	logStreamedToolDebug("WriteToFileToolDebug", event, payload)
 }
 
+function shouldPreserveXmlEntities(relPath: string): boolean {
+	return relPath.toLowerCase().endsWith(".xml")
+}
+
 export async function writeToFileTool(
 	cline: Task,
 	block: ToolUse,
@@ -123,7 +127,7 @@ export async function writeToFileTool(
 		newContent = newContent.split("\n").slice(0, -1).join("\n")
 	}
 
-	if (!cline.api.getModel().id.includes("claude")) {
+	if (!cline.api.getModel().id.includes("claude") && !shouldPreserveXmlEntities(relPath)) {
 		newContent = unescapeHtmlEntities(newContent)
 	}
 


### PR DESCRIPTION
- Updated write_to_file so XML files preserve escaped entities like < and > instead of converting them back to raw < and >.

- Added a regression test to verify XML metadata files keep escaped entities during save.

- Left the existing unescape behavior unchanged for non-XML files.