### PR TITLE
TypeScript Version Update

### DIFF
--- a/webview-ui/src/components/chat/__tests__/ChatView.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatView.spec.tsx
@@ -67,10 +67,7 @@ vi.mock("../../common/VersionIndicator", () => ({
 }))
 
 // Get the mock function after the module is mocked
-const mockVersionIndicator = vi.mocked(
-	// @ts-expect-error - accessing mocked module
-	(await import("../../common/VersionIndicator")).default,
-)
+const mockVersionIndicator = vi.mocked((await import("../../common/VersionIndicator")).default)
 
 vi.mock("../Announcement", () => ({
 	default: function MockAnnouncement({ hideAnnouncement }: { hideAnnouncement: () => void }) {

--- a/webview-ui/tsconfig.json
+++ b/webview-ui/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"types": ["vitest/globals"],
-		"target": "es5",
+		"target": "es2020",
 		"lib": ["dom", "dom.iterable", "esnext"],
 		"allowJs": true,
 		"skipLibCheck": true,
@@ -18,7 +18,6 @@
 		"isolatedModules": true,
 		"noEmit": true,
 		"jsx": "react-jsx",
-		"baseUrl": ".",
 		"paths": {
 			"@/*": ["./src/*"],
 			"@src/*": ["./src/*"],


### PR DESCRIPTION
chore(webview): modernize TypeScript config

Update the webview TypeScript target to ES2020, remove the unused baseUrl, and drop an unnecessary ts-expect-error from the ChatView test.