### PR TITLE
fix(task): don't leak an unhandled rejection when a task aborts during startup

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -398,6 +398,9 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		if (startTask) {
 			// Ensure todo list is initialized and present before starting any task.
 			this.ensureTodoListInitialized()
+			// A constructor can't await, so these run detached. startTask() and
+			// resumeTaskFromHistory() swallow abort-triggered rejections internally;
+			// anything else would otherwise surface as an unhandled rejection here.
 			if (task || images) {
 				this.startTask(task, images)
 			} else if (historyItem) {
@@ -1346,6 +1349,21 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	// Start / Abort / Resume
 
 	private async startTask(task?: string, images?: string[]): Promise<void> {
+		try {
+			await this.startTaskInner(task, images)
+		} catch (error) {
+			// Aborting while startup is still in flight is normal: abortTask() sets
+			// this.abort and returns without waiting, so the next say() in here
+			// throws. Callers that hold the promise (Task.create) already handle it,
+			// but the constructor path runs detached — rethrowing there would be an
+			// unhandled rejection. Only abort-triggered failures are swallowed.
+			if (!this.abort) {
+				throw error
+			}
+		}
+	}
+
+	private async startTaskInner(task?: string, images?: string[]): Promise<void> {
 		// `conversationHistory` (for API) and `clineMessages` (for webview)
 		// need to be in sync.
 		// If the extension process were killed, then on restart the
@@ -1530,6 +1548,17 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	}
 
 	private async resumeTaskFromHistory() {
+		try {
+			await this.resumeTaskFromHistoryInner()
+		} catch (error) {
+			// Same abort race as startTask() — see the comment there.
+			if (!this.abort) {
+				throw error
+			}
+		}
+	}
+
+	private async resumeTaskFromHistoryInner() {
 		const modifiedClineMessages = await this.getSavedClineMessages()
 
 		// Remove any resume messages that may have been added before

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -960,6 +960,45 @@ describe("Cline", () => {
 					await task.catch(() => {})
 				})
 			})
+
+			describe("abort during startup", () => {
+				it("should not reject when the task is aborted while starting", async () => {
+					const [cline, task] = Task.create({
+						provider: mockProvider,
+						apiConfiguration: mockApiConfig,
+						task: "test task",
+					})
+
+					// abortTask() sets this.abort and returns without waiting, so the
+					// in-flight startTask() hits a say() that throws. That rejection is
+					// expected and must not escape: on the constructor path nothing
+					// holds the promise, so it would become an unhandled rejection.
+					await cline.abortTask(true)
+
+					await expect(task).resolves.toBeUndefined()
+				})
+
+				it("should still surface non-abort startup failures", async () => {
+					// Fail before startTask() runs, so the rejection is guaranteed to
+					// come from inside it rather than racing the spy. this.abort stays
+					// false, so the guard must let this one through.
+					const saySpy = vi
+						.spyOn(Task.prototype as any, "say")
+						.mockRejectedValue(new Error("startup exploded"))
+
+					try {
+						const [, task] = Task.create({
+							provider: mockProvider,
+							apiConfiguration: mockApiConfig,
+							task: "test task",
+						})
+
+						await expect(task).rejects.toThrow("startup exploded")
+					} finally {
+						saySpy.mockRestore()
+					}
+				})
+			})
 		})
 
 		describe("Subtask Rate Limiting", () => {


### PR DESCRIPTION
Fixes an unhandled rejection that made the `src` suite exit non-zero **even with all 3412 tests passing** — the last blocker to adding a `pnpm test` step to CI.

## The bug

`abortTask()` sets `this.abort = true` and returns immediately; it does not wait for an in-flight startup. The detached `startTask()` then reaches its next `say()`, which throws by design once `abort` is set:

```
Error: [RooCode#say] task <id> aborted
  ❯ Task.say core/task/Task.ts:1175
  ❯ Task.startTask core/task/Task.ts:1379
```

`Task.create()` returns the promise so callers can handle this — and they do. But the **constructor** path (`Task.ts:402`/`404`) starts detached and keeps no reference, so there is nothing to catch it. The rejection escapes as an unhandled rejection.

This is not test-only. Aborting a task while it is still starting is an ordinary user action (hitting cancel during startup), and under Node's default unhandled-rejection behavior that is a crash rather than a clean cancel.

## The fix

`startTask()` and `resumeTaskFromHistory()` each wrap their body and swallow **only** abort-triggered failures:

```ts
if (!this.abort) {
    throw error
}
```

Narrow on purpose — if `abort` is false the error propagates exactly as before, so genuine startup failures are unaffected. Fixing it here rather than at the two call sites covers every caller, including `Task.create()`.

## Not introduced by the test repair

Reproduced on `882563e0b` — the pre-merge base, before #192 landed — where the identical rejection appears alongside the 6 failures that PR fixed. Pre-existing product bug, surfaced only once the tests around it went green.

## Tests

Two added, and I verified they are not vacuous by removing the guard and re-running:

- **`should not reject when the task is aborted while starting`** — fails without the guard (unhandled rejection → rejected promise). This is the regression test.
- **`should still surface non-abort startup failures`** — passes with and without the guard, by design: it pins that the guard stays narrow and does not swallow real errors. Without it, a future "fix" could catch everything and this PR's intent would be lost silently.

## Verification

- `pnpm --filter siid-code exec vitest run` — **262 files passed, 3414 passed, 142 skipped, exit 0, no `Errors` line.** (Previously: same passes, `Errors 1`, non-zero exit.)
- `npx tsc --noEmit` — clean
- prettier + eslint via pre-commit hook — clean

## Follow-up

With this merged, `pnpm test` can be added to the `pr-checks` job in `build-auto-version.yml`. CI currently runs lint, check-types, format, and build but **no tests at all**, which is how these suites drifted to 263 + 83 failures unnoticed.

Needs the same cherry-pick onto `main-stable-agent` as #194/#195.