### PR TITLE
fix(task): don't leak an unhandled rejection when a task aborts during startup [main-stable-agent]

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -423,6 +423,9 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		if (startTask) {
 			// Ensure todo list is initialized and present before starting any task.
 			this.ensureTodoListInitialized()
+			// A constructor can't await, so these run detached. startTask() and
+			// resumeTaskFromHistory() swallow abort-triggered rejections internally;
+			// anything else would otherwise surface as an unhandled rejection here.
 			if (task || images) {
 				this.startTask(task, images)
 			} else if (historyItem) {
@@ -1412,6 +1415,21 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	// Start / Abort / Resume
 
 	private async startTask(task?: string, images?: string[]): Promise<void> {
+		try {
+			await this.startTaskInner(task, images)
+		} catch (error) {
+			// Aborting while startup is still in flight is normal: abortTask() sets
+			// this.abort and returns without waiting, so the next say() in here
+			// throws. Callers that hold the promise (Task.create) already handle it,
+			// but the constructor path runs detached — rethrowing there would be an
+			// unhandled rejection. Only abort-triggered failures are swallowed.
+			if (!this.abort) {
+				throw error
+			}
+		}
+	}
+
+	private async startTaskInner(task?: string, images?: string[]): Promise<void> {
 		// `conversationHistory` (for API) and `clineMessages` (for webview)
 		// need to be in sync.
 		// If the extension process were killed, then on restart the
@@ -1599,6 +1617,17 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	}
 
 	private async resumeTaskFromHistory() {
+		try {
+			await this.resumeTaskFromHistoryInner()
+		} catch (error) {
+			// Same abort race as startTask() — see the comment there.
+			if (!this.abort) {
+				throw error
+			}
+		}
+	}
+
+	private async resumeTaskFromHistoryInner() {
 		const modifiedClineMessages = await this.getSavedClineMessages()
 
 		// Remove any resume messages that may have been added before

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -960,6 +960,45 @@ describe("Cline", () => {
 					await task.catch(() => {})
 				})
 			})
+
+			describe("abort during startup", () => {
+				it("should not reject when the task is aborted while starting", async () => {
+					const [cline, task] = Task.create({
+						provider: mockProvider,
+						apiConfiguration: mockApiConfig,
+						task: "test task",
+					})
+
+					// abortTask() sets this.abort and returns without waiting, so the
+					// in-flight startTask() hits a say() that throws. That rejection is
+					// expected and must not escape: on the constructor path nothing
+					// holds the promise, so it would become an unhandled rejection.
+					await cline.abortTask(true)
+
+					await expect(task).resolves.toBeUndefined()
+				})
+
+				it("should still surface non-abort startup failures", async () => {
+					// Fail before startTask() runs, so the rejection is guaranteed to
+					// come from inside it rather than racing the spy. this.abort stays
+					// false, so the guard must let this one through.
+					const saySpy = vi
+						.spyOn(Task.prototype as any, "say")
+						.mockRejectedValue(new Error("startup exploded"))
+
+					try {
+						const [, task] = Task.create({
+							provider: mockProvider,
+							apiConfiguration: mockApiConfig,
+							task: "test task",
+						})
+
+						await expect(task).rejects.toThrow("startup exploded")
+					} finally {
+						saySpy.mockRestore()
+					}
+				})
+			})
 		})
 
 		describe("Subtask Rate Limiting", () => {


### PR DESCRIPTION
`main-stable-agent` counterpart of #196. Clean cherry-pick of `df4926edf`, re-verified on this base.

## The bug

`abortTask()` sets `this.abort = true` and returns without waiting for an in-flight startup. The detached `startTask()` then reaches its next `say()`, which throws by design once `abort` is set. `Task.create()` returns the promise and callers handle it — but the **constructor** path starts detached and keeps no reference, so nothing catches the rejection and it escapes unhandled.

Real product bug, not test-only: cancelling a task while it is still starting is ordinary user behavior, and under Node's default unhandled-rejection handling that is a crash rather than a clean cancel.

## The fix

`startTask()` and `resumeTaskFromHistory()` wrap their bodies and swallow **only** abort-triggered failures:

```ts
if (!this.abort) {
    throw error
}
```

Narrow by design — with `abort` false the error propagates unchanged, so genuine startup failures are unaffected.

## Verification on this base

Re-run here rather than inherited from the cherry-pick:

- `npx vitest run` (full src) — **264 files passed, 3443 passed, 142 skipped, exit 0, no `Errors` line.** The higher count vs #196's 3414 reflects this base's extra content.
- `npx tsc --noEmit` — clean
- prettier + eslint via pre-commit hook — clean

## Tests

Same two as #196, both verified non-vacuous by removing the guard and re-running:

- `should not reject when the task is aborted while starting` — fails without the guard; this is the regression test.
- `should still surface non-abort startup failures` — passes with and without the guard by design, pinning that the guard stays narrow and cannot silently grow into a catch-all.

## Follow-up

With this and #196 merged, both bases have a green `src` suite that exits 0. A `pnpm test` step can then be added to the `pr-checks` job in `build-auto-version.yml` — CI currently runs lint, check-types, format, and build but **no tests at all**, which is how these suites drifted to 263 + 83 failures unnoticed.