### PR TITLE
ci: run tests on PRs [main-stable-agent]

### DIFF
--- a/.github/workflows/build-auto-version.yml
+++ b/.github/workflows/build-auto-version.yml
@@ -1,616 +1,620 @@
 name: Siid-Code Auto-Version & Release
 
 on:
-  push:
-    branches: 
-      - main
-      - main-stable-agent
-  pull_request:
-    branches:
-      - main
-      - main-stable-agent
-    types: [opened, synchronize, reopened]
-  workflow_dispatch:
-    inputs:
-      version_bump:
-        description: 'Version bump type (auto/major/minor/patch)'
-        required: false
-        type: choice
-        options:
-          - auto
-          - major
-          - minor
-          - patch
-        default: 'auto'
-      prerelease:
-        description: 'Mark as pre-release/preview'
-        required: false
-        type: boolean
-        default: false
+    push:
+        branches:
+            - main
+            - main-stable-agent
+    pull_request:
+        branches:
+            - main
+            - main-stable-agent
+        types: [opened, synchronize, reopened]
+    workflow_dispatch:
+        inputs:
+            version_bump:
+                description: "Version bump type (auto/major/minor/patch)"
+                required: false
+                type: choice
+                options:
+                    - auto
+                    - major
+                    - minor
+                    - patch
+                default: "auto"
+            prerelease:
+                description: "Mark as pre-release/preview"
+                required: false
+                type: boolean
+                default: false
 
 jobs:
-  # Job 1: PR Quality Checks (runs on pull requests)
-  pr-checks:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: '10.8.1'
-          
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.19.2'
-          cache: 'pnpm'
-          
-      - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
-        
-      - name: Run linting
-        run: pnpm lint
-        
-      - name: Run type checking
-        run: pnpm check-types
-        
-      - name: Run formatting check
-        run: pnpm format
-        
-      - name: Build project
-        run: pnpm build
-        
-      - name: Check build output
-        run: |
-          echo "✅ Build completed successfully!"
-          if [ -d "out" ]; then
-            echo "📁 Build output (out directory):"
-            ls -la out/ | head -10
-            echo "📦 Bundle size (out):"
-            du -sh out/
-          fi
-          if [ -d "dist" ]; then
-            echo "📁 Build output (dist directory):"
-            ls -la dist/ | head -10
-            echo "📦 Bundle size (dist):"
-            du -sh dist/
-          fi
-          
-      - name: Security audit
-        run: |
-          pnpm audit --audit-level moderate || echo "⚠️ Security audit completed with warnings"
-          
-      - name: Check package.json scripts
-        run: |
-          echo "📋 Available scripts:"
-          node -p "Object.keys(require('./package.json').scripts || {}).join('\n')"
-          
-      - name: Analyze commit message
-        run: |
-          echo "## 📝 Commit Message Analysis" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          COMMIT_MSG=$(git log -1 --pretty=format:"%s")
-          echo "**Latest commit:** \`$COMMIT_MSG\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          if echo "$COMMIT_MSG" | grep -qiE "^(feat|fix|docs|chore|refactor|perf|test|style|ci)(\(.*\))?:"; then
-            echo "✅ Commit follows conventional commit format" >> $GITHUB_STEP_SUMMARY
-            
-            if echo "$COMMIT_MSG" | grep -qiE "^feat!:|^fix!:|BREAKING CHANGE"; then
-              echo "🔴 **MAJOR** version bump (breaking change)" >> $GITHUB_STEP_SUMMARY
-            elif echo "$COMMIT_MSG" | grep -qiE "^feat(\(.*\))?:"; then
-              echo "🟡 **MINOR** version bump (new feature)" >> $GITHUB_STEP_SUMMARY
-            elif echo "$COMMIT_MSG" | grep -qiE "^fix(\(.*\))?:"; then
-              echo "🟢 **PATCH** version bump (bug fix)" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "🟢 **PATCH** version bump (maintenance)" >> $GITHUB_STEP_SUMMARY
-            fi
-          else
-            echo "⚠️ Commit does not follow conventional commit format" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Recommended format:**" >> $GITHUB_STEP_SUMMARY
-            echo "- \`feat: add new feature\` (MINOR bump)" >> $GITHUB_STEP_SUMMARY
-            echo "- \`fix: resolve bug\` (PATCH bump)" >> $GITHUB_STEP_SUMMARY
-            echo "- \`feat!: breaking change\` (MAJOR bump)" >> $GITHUB_STEP_SUMMARY
-          fi
-          
-      - name: PR Status Summary
-        run: |
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "---" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "## ✅ All PR Checks Passed!" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| 🔍 Linting | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
-          echo "| 📝 Type Checking | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
-          echo "| 💅 Formatting | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
-          echo "| 🔨 Build | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
-          echo "| 🔒 Security Audit | ✅ Checked |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✨ **This PR is ready for review and merge!**" >> $GITHUB_STEP_SUMMARY
+    # Job 1: PR Quality Checks (runs on pull requests)
+    pr-checks:
+        runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request'
 
-  # Job 2: Auto-Version and Release (runs on push to main branches)
-  auto-version-and-release:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-stable-agent')
-    
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: '10.8.1'
-          
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.19.2'
-          cache: 'pnpm'
-          
-      - name: Get latest tag
-        id: get_latest_tag
-        run: |
-          echo "🔍 Searching for latest CalVer tag (YEAR.MAJOR.MINOR format)..."
-          
-          # Get all v*.*.* tags
-          ALL_TAGS=$(git tag -l "v*.*.*")
-          
-          # Filter to ONLY CalVer versions (YEAR >= 2000)
-          LATEST_TAG=$(echo "$ALL_TAGS" | while read tag; do
-            if [ -n "$tag" ]; then
-              # Strip suffixes like -agent or -alpha.X before numeric parsing
-              BASE_TAG=${tag%%-*}
-              VERSION=${BASE_TAG#v}
-              IFS='.' read -r YEAR MAJOR MINOR <<< "$VERSION"
-              # Only include tags where YEAR >= 2000 (CalVer versions)
-              if [ "$YEAR" -eq "$YEAR" ] 2>/dev/null && \
-                 [ "$MAJOR" -eq "$MAJOR" ] 2>/dev/null && \
-                 [ "$MINOR" -eq "$MINOR" ] 2>/dev/null && \
-                 [ "$YEAR" -ge 2000 ]; then
-                echo "$YEAR $MAJOR $MINOR $tag"
-              fi
-            fi
-          done | sort -k1,1n -k2,2n -k3,3n | tail -n 1 | awk '{print $4}')
-          
-          # Get current year
-          CURRENT_YEAR=$(date +'%Y')
-          
-          # If no CalVer tag found, start fresh with current year
-          if [ -z "$LATEST_TAG" ]; then
-            echo "⚠️  No CalVer tags found"
-            echo "✨ Starting fresh with v$CURRENT_YEAR.0.0"
-            LATEST_TAG="v$CURRENT_YEAR.0.0"
-            IS_FIRST_RELEASE="true"
-          else
-            echo "✅ Found latest CalVer version: $LATEST_TAG"
-            IS_FIRST_RELEASE="false"
-          fi
-          
-          # Extract version numbers (remove 'v' prefix and any suffix)
-          VERSION=${LATEST_TAG#v}
-          VERSION=${VERSION%%-*}
-          
-          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
-          echo "current_version=$VERSION" >> $GITHUB_OUTPUT
-          echo "is_first_release=$IS_FIRST_RELEASE" >> $GITHUB_OUTPUT
-          echo ""
-          echo "📌 Using version: $LATEST_TAG"
-          
-      - name: Analyze commits for version bump
-        id: analyze_commits
-        run: |
-          LATEST_TAG="${{ steps.get_latest_tag.outputs.latest_tag }}"
-          IS_FIRST_RELEASE="${{ steps.get_latest_tag.outputs.is_first_release }}"
-          
-          if [ "$IS_FIRST_RELEASE" = "true" ]; then
-            echo "🎉 First CalVer release - analyzing recent commits"
-            COMMITS=$(git log --pretty=format:"%s" --no-merges -20)
-          else
-            echo "📌 Analyzing commits since: $LATEST_TAG"
-            
-            # Check if the tag actually exists in the repository
-            if git rev-parse "$LATEST_TAG" >/dev/null 2>&1; then
-              COMMITS=$(git log $LATEST_TAG..HEAD --pretty=format:"%s" --no-merges)
-            else
-              echo "⚠️  Tag $LATEST_TAG does not exist in repository"
-              echo "📝 Analyzing recent commits (last 20)"
-              COMMITS=$(git log --pretty=format:"%s" --no-merges | head -20)
-            fi
-          fi
-          
-          echo "Commits analyzed:"
-          echo "$COMMITS"
-          echo ""
-          
-          # Determine bump type based on conventional commits
-          BUMP_TYPE="patch"
-          
-          # Check for breaking changes (MAJOR)
-          if echo "$COMMITS" | grep -qiE "^(BREAKING CHANGE:|feat!:|fix!:|refactor!:)"; then
-            BUMP_TYPE="major"
-            echo "🔴 BREAKING CHANGE detected → MAJOR version bump"
-          # Check for new features (MINOR)
-          elif echo "$COMMITS" | grep -qiE "^feat(\(.*\))?:"; then
-            BUMP_TYPE="minor"
-            echo "🟡 New feature detected → MINOR version bump"
-          # Check for fixes or other changes (PATCH)
-          elif echo "$COMMITS" | grep -qiE "^(fix|perf|refactor|docs|chore|style|test)(\(.*\))?:"; then
-            BUMP_TYPE="patch"
-            echo "🟢 Fix/improvement detected → PATCH version bump"
-          else
-            BUMP_TYPE="patch"
-            echo "⚪ No conventional commits → default PATCH version bump"
-          fi
-          
-          echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
-          
-      - name: Calculate new version
-        id: calc_version
-        run: |
-          CURRENT_VERSION="${{ steps.get_latest_tag.outputs.current_version }}"
-          IS_FIRST_RELEASE="${{ steps.get_latest_tag.outputs.is_first_release }}"
-          BUMP_TYPE="${{ github.event.inputs.version_bump || steps.analyze_commits.outputs.bump_type }}"
-          PRERELEASE="${{ github.event.inputs.prerelease }}"
-          
-          echo "Current version: $CURRENT_VERSION"
-          echo "First release: $IS_FIRST_RELEASE"
-          echo "Bump type: $BUMP_TYPE"
-          echo "Prerelease: $PRERELEASE"
-          echo ""
-          
-          # Get current year
-          CURRENT_YEAR=$(date +'%Y')
-          
-          if [ "$IS_FIRST_RELEASE" = "true" ]; then
-            # This is the first CalVer release
-            NEW_VERSION="$CURRENT_YEAR.0.0"
-            echo "🎉 First CalVer release: $NEW_VERSION"
-          else
-            # Parse current version (format: YEAR.MAJOR.MINOR or YEAR.MAJOR.MINOR-alpha.X)
-            # Remove any prerelease suffix first
-            BASE_VERSION="${CURRENT_VERSION%%-*}"
-            IFS='.' read -r YEAR MAJOR MINOR <<< "$BASE_VERSION"
-            
-            # If year changed, reset to YEAR.0.0
-            if [ "$YEAR" != "$CURRENT_YEAR" ]; then
-              NEW_VERSION="$CURRENT_YEAR.0.0"
-              echo "📅 New year detected! Resetting to $NEW_VERSION"
-            else
-              # Apply version bump based on CalVer rules
-              case $BUMP_TYPE in
-                major)
-                  MAJOR=$((MAJOR + 1))
-                  MINOR=0
-                  echo "🔴 MAJOR bump: $CURRENT_VERSION → $CURRENT_YEAR.$MAJOR.$MINOR"
-                  ;;
-                minor)
-                  MINOR=$((MINOR + 1))
-                  echo "🟡 MINOR bump: $CURRENT_VERSION → $CURRENT_YEAR.$MAJOR.$MINOR"
-                  ;;
-                patch|auto)
-                  MINOR=$((MINOR + 1))
-                  echo "🟢 PATCH bump (increments MINOR in CalVer): $CURRENT_VERSION → $CURRENT_YEAR.$MAJOR.$MINOR"
-                  ;;
-              esac
-              
-              # Build version string (with or without prerelease suffix)
-              if [ "$PRERELEASE" = "true" ]; then
-                NEW_VERSION="$CURRENT_YEAR.$MAJOR.$MINOR-alpha.$MINOR"
-                echo "🔵 Prerelease version: $NEW_VERSION"
-              else
-                NEW_VERSION="$CURRENT_YEAR.$MAJOR.$MINOR"
-                echo "✅ Stable version: $NEW_VERSION"
-              fi
-            fi
-          fi
-          
-          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-          TAG_SUFFIX=""
-          if [ "$BRANCH_NAME" = "main-stable-agent" ]; then
-            TAG_SUFFIX="-agent"
-          fi
-          NEW_TAG="v$NEW_VERSION$TAG_SUFFIX"
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
-          
-      - name: Check if version already exists
-        id: check_version
-        run: |
-          NEW_TAG="${{ steps.calc_version.outputs.new_tag }}"
-          
-          if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
-            echo "⚠️  Tag $NEW_TAG already exists!"
-            echo "version_exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "✅ Tag $NEW_TAG is available"
-            echo "version_exists=false" >> $GITHUB_OUTPUT
-          fi
-          
-      - name: Update package.json version
-        if: steps.check_version.outputs.version_exists == 'false'
-        run: |
-          NEW_VERSION="${{ steps.calc_version.outputs.new_version }}"
-          echo "📝 Updating package.json to version $NEW_VERSION"
-          
-          # Get current package.json version
-          CURRENT_PKG_VERSION=$(node -p "require('./src/package.json').version")
-          echo "Current package.json version: $CURRENT_PKG_VERSION"
-          
-          # Update version in package.json (only if different)
-          if [ "$CURRENT_PKG_VERSION" != "$NEW_VERSION" ]; then
-            node -e "
-              const fs = require('fs');
-              const pkg = JSON.parse(fs.readFileSync('./src/package.json', 'utf8'));
-              pkg.version = '$NEW_VERSION';
-              fs.writeFileSync('./src/package.json', JSON.stringify(pkg, null, 2) + '\n');
-            "
-            echo "✅ package.json version updated to: $NEW_VERSION"
-          else
-            echo "ℹ️  package.json already at version $NEW_VERSION, skipping update"
-          fi
-          
-          # Verify the changes
-          PACKAGE_VERSION=$(node -p "require('./src/package.json').version")
-          echo "✅ Final package.json version: $PACKAGE_VERSION"
-          
-      - name: Commit version bump
-        if: steps.check_version.outputs.version_exists == 'false'
-        run: |
-          NEW_VERSION="${{ steps.calc_version.outputs.new_version }}"
-          
-          # Check if there are any changes to commit
-          if git diff --quiet src/package.json; then
-            echo "ℹ️  No version changes detected, skipping commit"
-          else
-            # Configure git
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            
-            # Commit and push
-            git add src/package.json
-            git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
-            git push
-            
-            echo "✅ Version changes committed and pushed to main branch"
-          fi
-          
-      - name: Install dependencies
-        if: steps.check_version.outputs.version_exists == 'false'
-        run: pnpm install --no-frozen-lockfile
-        
-      - name: Run linting
-        if: steps.check_version.outputs.version_exists == 'false'
-        run: pnpm lint
-        
-      - name: Run type checking
-        if: steps.check_version.outputs.version_exists == 'false'
-        run: pnpm check-types
-        
-      - name: Build project
-        if: steps.check_version.outputs.version_exists == 'false'
-        run: pnpm build
-        
-      - name: Check build output
-        if: steps.check_version.outputs.version_exists == 'false'
-        run: |
-          echo "Build completed successfully!"
-          if [ -d "out" ]; then
-            echo "📁 Build output (out directory):"
-            ls -la out/ | head -10
-          fi
-          if [ -d "dist" ]; then
-            echo "📁 Build output (dist directory):"
-            ls -la dist/ | head -10
-          fi
-          
-      - name: Create VSIX package
-        if: steps.check_version.outputs.version_exists == 'false'
-        run: pnpm vsix
-        
-      - name: Find VSIX file
-        if: steps.check_version.outputs.version_exists == 'false'
-        id: find_vsix
-        run: |
-          # Look for VSIX files in common locations
-          VSIX_FILE=""
-          if [ -d "bin" ] && [ "$(ls bin/*.vsix 2>/dev/null | wc -l)" -gt 0 ]; then
-            VSIX_FILE=$(ls bin/*.vsix | head -1)
-          elif [ "$(ls *.vsix 2>/dev/null | wc -l)" -gt 0 ]; then
-            VSIX_FILE=$(ls *.vsix | head -1)
-          fi
-          
-          if [ -n "$VSIX_FILE" ]; then
-            echo "Found VSIX: $VSIX_FILE"
-            echo "vsix_path=$VSIX_FILE" >> $GITHUB_OUTPUT
-            echo "vsix_name=$(basename $VSIX_FILE)" >> $GITHUB_OUTPUT
-          else
-            echo "Error: No VSIX file found!"
-            exit 1
-          fi
-          
-      - name: Generate checksums
-        if: steps.check_version.outputs.version_exists == 'false'
-        id: checksums
-        run: |
-          VSIX_FILE="${{ steps.find_vsix.outputs.vsix_path }}"
-          SHA256=$(sha256sum "$VSIX_FILE" | awk '{print $1}')
-          echo "$SHA256" > "${VSIX_FILE}.sha256"
-          echo "sha256=$SHA256" >> $GITHUB_OUTPUT
-          echo "✓ Checksum generated"
-          echo "SHA256: $SHA256"
-          
-      - name: Get build timestamp
-        id: timestamp
-        run: |
-          echo "build_date=$(date +'%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_OUTPUT
-          echo "build_date_compact=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
-          
-      - name: Generate changelog
-        id: changelog
-        run: |
-          LATEST_TAG="${{ steps.get_latest_tag.outputs.latest_tag }}"
-          IS_FIRST_RELEASE="${{ steps.get_latest_tag.outputs.is_first_release }}"
-          
-          if [ "$IS_FIRST_RELEASE" = "true" ]; then
-            echo "🎉 First CalVer release - showing recent commits"
-            COMMITS=$(git log --pretty=format:"- %s by @%an in %h" --no-merges -20)
-          else
-            echo "📋 Generating changelog from $LATEST_TAG to HEAD"
-            
-            # Check if the tag actually exists in the repository
-            if git rev-parse "$LATEST_TAG" >/dev/null 2>&1; then
-              COMMITS=$(git log $LATEST_TAG..HEAD --pretty=format:"- %s by @%an in %h" --no-merges)
-            else
-              echo "⚠️  Tag $LATEST_TAG does not exist in repository"
-              echo "📝 Showing recent commits (last 20)"
-              COMMITS=$(git log --pretty=format:"- %s by @%an in %h" --no-merges -20)
-            fi
-          fi
-          
-          # Check if there are any commits
-          if [ -z "$COMMITS" ]; then
-            COMMITS="- No changes since last release"
-          fi
-          
-          # Save to file
-          echo "$COMMITS" > changelog.txt
-          
-          # Read into output
-          CHANGELOG=$(cat changelog.txt)
-          echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGELOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          
-      - name: Get contributors
-        id: contributors
-        run: |
-          LATEST_TAG="${{ steps.get_latest_tag.outputs.latest_tag }}"
-          IS_FIRST_RELEASE="${{ steps.get_latest_tag.outputs.is_first_release }}"
-          
-          if [ "$IS_FIRST_RELEASE" = "true" ]; then
-            CONTRIBUTORS=$(git log --pretty=format:"%an" --no-merges | sort -u | head -10 | sed 's/^/@/' | paste -sd ", " -)
-          else
-            if git rev-parse "$LATEST_TAG" >/dev/null 2>&1; then
-              CONTRIBUTORS=$(git log $LATEST_TAG..HEAD --pretty=format:"%an" --no-merges | sort -u | sed 's/^/@/' | paste -sd ", " -)
-            else
-              CONTRIBUTORS=$(git log --pretty=format:"%an" --no-merges | sort -u | head -10 | sed 's/^/@/' | paste -sd ", " -)
-            fi
-          fi
-          
-          if [ -z "$CONTRIBUTORS" ]; then
-            CONTRIBUTORS="@${{ github.actor }}"
-          fi
-          
-          echo "contributors=$CONTRIBUTORS" >> $GITHUB_OUTPUT
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: "10.8.1"
 
-      - name: Get release quality
-        id: release_quality
-        run: |
-          QUALITY=$(node -p "require('./src/package.json').releaseQuality || 'stable'")
-          echo "quality=$QUALITY" >> $GITHUB_OUTPUT
-          echo "Using release quality: $QUALITY"
-          
-      - name: Create Release
-        if: steps.check_version.outputs.version_exists == 'false'
-        uses: softprops/action-gh-release@v1
-        with:
-          name: "SIID Code Extension v${{ steps.calc_version.outputs.new_version }} (${{ steps.release_quality.outputs.quality }})"
-          tag_name: ${{ steps.calc_version.outputs.new_tag }}
-          draft: false
-          prerelease: ${{ github.event.inputs.prerelease || 'false' }}
-          generate_release_notes: false
-          body: |
-            ## SIID Code Extension Package
-            
-            **Build Date:** ${{ steps.timestamp.outputs.build_date }}
-            **Version:** v${{ steps.calc_version.outputs.new_version }}
-            **Version Bump:** ${{ steps.analyze_commits.outputs.bump_type }}
-            **Release Quality:** ${{ steps.release_quality.outputs.quality }}
-            
-            ---
-            
-            ### 📦 Downloads
-            
-            | Package | Description |
-            |---------|-------------|
-            | **${{ steps.find_vsix.outputs.vsix_name }}** | VS Code Extension Package (install via Extensions view or `code --install-extension`) |
-            
-            ### 🔐 Checksums
-            Use the .sha256 files to verify your download integrity.
-            
-            ---
-            
-            ### 📝 What's Changed
-            
-            ${{ steps.changelog.outputs.changelog }}
-            
-            **Full Changelog:** ${{ github.server_url }}/${{ github.repository }}/compare/${{ steps.get_latest_tag.outputs.latest_tag }}...${{ steps.calc_version.outputs.new_tag }}
-            
-            ---
-            
-            ### 👥 Contributors
-            
-            ${{ steps.contributors.outputs.contributors }}
-            
-            ---
-            
-            ### 📋 Version Information
-            
-            SIID Code follows **Calendar Versioning (CalVer)**: `YEAR.MAJOR.MINOR`
-            - **YEAR**: Current year (e.g., 2025)
-            - **MAJOR**: Breaking changes or significant new features
-            - **MINOR**: New features (backward compatible) or bug fixes
-            - Version resets at year boundary (e.g., 2025.x.x → 2026.0.0)
-          files: |
-            ${{ steps.find_vsix.outputs.vsix_path }}
-            ${{ steps.find_vsix.outputs.vsix_path }}.sha256
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Upload Build Artifacts
-        if: steps.check_version.outputs.version_exists == 'false'
-        uses: actions/upload-artifact@v4
-        with:
-          name: siid-code-extension-v${{ steps.calc_version.outputs.new_version }}-${{ steps.release_quality.outputs.quality }}
-          path: |
-            ${{ steps.find_vsix.outputs.vsix_path }}
-            ${{ steps.find_vsix.outputs.vsix_path }}.sha256
-          retention-days: 90
-          
-      - name: Summary
-        if: always()
-        run: |
-          echo "## 📊 Build Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Previous Version | \`${{ steps.get_latest_tag.outputs.latest_tag }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| New Version | \`${{ steps.calc_version.outputs.new_tag }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Bump Type | **${{ steps.analyze_commits.outputs.bump_type }}** |" >> $GITHUB_STEP_SUMMARY
-          echo "| Build Date | ${{ steps.timestamp.outputs.build_date }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Version Exists | ${{ steps.check_version.outputs.version_exists }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Prerelease | ${{ github.event.inputs.prerelease || 'false' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          if [ "${{ steps.check_version.outputs.version_exists }}" == "true" ]; then
-            echo "### ⚠️ Warning" >> $GITHUB_STEP_SUMMARY
-            echo "Version ${{ steps.calc_version.outputs.new_tag }} already exists. Build was skipped." >> $GITHUB_STEP_SUMMARY
-          else
-            echo "### ✅ Success" >> $GITHUB_STEP_SUMMARY
-            echo "Release ${{ steps.calc_version.outputs.new_tag }} created successfully!" >> $GITHUB_STEP_SUMMARY
-          fi
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "20.19.2"
+                  cache: "pnpm"
+
+            - name: Install dependencies
+              run: pnpm install --no-frozen-lockfile
+
+            - name: Run linting
+              run: pnpm lint
+
+            - name: Run type checking
+              run: pnpm check-types
+
+            - name: Run tests
+              run: pnpm test
+
+            - name: Run formatting check
+              run: pnpm format
+
+            - name: Build project
+              run: pnpm build
+
+            - name: Check build output
+              run: |
+                  echo "✅ Build completed successfully!"
+                  if [ -d "out" ]; then
+                    echo "📁 Build output (out directory):"
+                    ls -la out/ | head -10
+                    echo "📦 Bundle size (out):"
+                    du -sh out/
+                  fi
+                  if [ -d "dist" ]; then
+                    echo "📁 Build output (dist directory):"
+                    ls -la dist/ | head -10
+                    echo "📦 Bundle size (dist):"
+                    du -sh dist/
+                  fi
+
+            - name: Security audit
+              run: |
+                  pnpm audit --audit-level moderate || echo "⚠️ Security audit completed with warnings"
+
+            - name: Check package.json scripts
+              run: |
+                  echo "📋 Available scripts:"
+                  node -p "Object.keys(require('./package.json').scripts || {}).join('\n')"
+
+            - name: Analyze commit message
+              run: |
+                  echo "## 📝 Commit Message Analysis" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+
+                  COMMIT_MSG=$(git log -1 --pretty=format:"%s")
+                  echo "**Latest commit:** \`$COMMIT_MSG\`" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+
+                  if echo "$COMMIT_MSG" | grep -qiE "^(feat|fix|docs|chore|refactor|perf|test|style|ci)(\(.*\))?:"; then
+                    echo "✅ Commit follows conventional commit format" >> $GITHUB_STEP_SUMMARY
+                    
+                    if echo "$COMMIT_MSG" | grep -qiE "^feat!:|^fix!:|BREAKING CHANGE"; then
+                      echo "🔴 **MAJOR** version bump (breaking change)" >> $GITHUB_STEP_SUMMARY
+                    elif echo "$COMMIT_MSG" | grep -qiE "^feat(\(.*\))?:"; then
+                      echo "🟡 **MINOR** version bump (new feature)" >> $GITHUB_STEP_SUMMARY
+                    elif echo "$COMMIT_MSG" | grep -qiE "^fix(\(.*\))?:"; then
+                      echo "🟢 **PATCH** version bump (bug fix)" >> $GITHUB_STEP_SUMMARY
+                    else
+                      echo "🟢 **PATCH** version bump (maintenance)" >> $GITHUB_STEP_SUMMARY
+                    fi
+                  else
+                    echo "⚠️ Commit does not follow conventional commit format" >> $GITHUB_STEP_SUMMARY
+                    echo "" >> $GITHUB_STEP_SUMMARY
+                    echo "**Recommended format:**" >> $GITHUB_STEP_SUMMARY
+                    echo "- \`feat: add new feature\` (MINOR bump)" >> $GITHUB_STEP_SUMMARY
+                    echo "- \`fix: resolve bug\` (PATCH bump)" >> $GITHUB_STEP_SUMMARY
+                    echo "- \`feat!: breaking change\` (MAJOR bump)" >> $GITHUB_STEP_SUMMARY
+                  fi
+
+            - name: PR Status Summary
+              run: |
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "---" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "## ✅ All PR Checks Passed!" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
+                  echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+                  echo "| 🔍 Linting | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
+                  echo "| 📝 Type Checking | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
+                  echo "| 🧪 Tests | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
+                  echo "| 💅 Formatting | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
+                  echo "| 🔨 Build | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
+                  echo "| 🔒 Security Audit | ✅ Checked |" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "✨ **This PR is ready for review and merge!**" >> $GITHUB_STEP_SUMMARY
+
+    # Job 2: Auto-Version and Release (runs on push to main branches)
+    auto-version-and-release:
+        runs-on: ubuntu-latest
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-stable-agent')
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: "10.8.1"
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "20.19.2"
+                  cache: "pnpm"
+
+            - name: Get latest tag
+              id: get_latest_tag
+              run: |
+                  echo "🔍 Searching for latest CalVer tag (YEAR.MAJOR.MINOR format)..."
+
+                  # Get all v*.*.* tags
+                  ALL_TAGS=$(git tag -l "v*.*.*")
+
+                  # Filter to ONLY CalVer versions (YEAR >= 2000)
+                  LATEST_TAG=$(echo "$ALL_TAGS" | while read tag; do
+                    if [ -n "$tag" ]; then
+                      # Strip suffixes like -agent or -alpha.X before numeric parsing
+                      BASE_TAG=${tag%%-*}
+                      VERSION=${BASE_TAG#v}
+                      IFS='.' read -r YEAR MAJOR MINOR <<< "$VERSION"
+                      # Only include tags where YEAR >= 2000 (CalVer versions)
+                      if [ "$YEAR" -eq "$YEAR" ] 2>/dev/null && \
+                         [ "$MAJOR" -eq "$MAJOR" ] 2>/dev/null && \
+                         [ "$MINOR" -eq "$MINOR" ] 2>/dev/null && \
+                         [ "$YEAR" -ge 2000 ]; then
+                        echo "$YEAR $MAJOR $MINOR $tag"
+                      fi
+                    fi
+                  done | sort -k1,1n -k2,2n -k3,3n | tail -n 1 | awk '{print $4}')
+
+                  # Get current year
+                  CURRENT_YEAR=$(date +'%Y')
+
+                  # If no CalVer tag found, start fresh with current year
+                  if [ -z "$LATEST_TAG" ]; then
+                    echo "⚠️  No CalVer tags found"
+                    echo "✨ Starting fresh with v$CURRENT_YEAR.0.0"
+                    LATEST_TAG="v$CURRENT_YEAR.0.0"
+                    IS_FIRST_RELEASE="true"
+                  else
+                    echo "✅ Found latest CalVer version: $LATEST_TAG"
+                    IS_FIRST_RELEASE="false"
+                  fi
+
+                  # Extract version numbers (remove 'v' prefix and any suffix)
+                  VERSION=${LATEST_TAG#v}
+                  VERSION=${VERSION%%-*}
+
+                  echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+                  echo "current_version=$VERSION" >> $GITHUB_OUTPUT
+                  echo "is_first_release=$IS_FIRST_RELEASE" >> $GITHUB_OUTPUT
+                  echo ""
+                  echo "📌 Using version: $LATEST_TAG"
+
+            - name: Analyze commits for version bump
+              id: analyze_commits
+              run: |
+                  LATEST_TAG="${{ steps.get_latest_tag.outputs.latest_tag }}"
+                  IS_FIRST_RELEASE="${{ steps.get_latest_tag.outputs.is_first_release }}"
+
+                  if [ "$IS_FIRST_RELEASE" = "true" ]; then
+                    echo "🎉 First CalVer release - analyzing recent commits"
+                    COMMITS=$(git log --pretty=format:"%s" --no-merges -20)
+                  else
+                    echo "📌 Analyzing commits since: $LATEST_TAG"
+                    
+                    # Check if the tag actually exists in the repository
+                    if git rev-parse "$LATEST_TAG" >/dev/null 2>&1; then
+                      COMMITS=$(git log $LATEST_TAG..HEAD --pretty=format:"%s" --no-merges)
+                    else
+                      echo "⚠️  Tag $LATEST_TAG does not exist in repository"
+                      echo "📝 Analyzing recent commits (last 20)"
+                      COMMITS=$(git log --pretty=format:"%s" --no-merges | head -20)
+                    fi
+                  fi
+
+                  echo "Commits analyzed:"
+                  echo "$COMMITS"
+                  echo ""
+
+                  # Determine bump type based on conventional commits
+                  BUMP_TYPE="patch"
+
+                  # Check for breaking changes (MAJOR)
+                  if echo "$COMMITS" | grep -qiE "^(BREAKING CHANGE:|feat!:|fix!:|refactor!:)"; then
+                    BUMP_TYPE="major"
+                    echo "🔴 BREAKING CHANGE detected → MAJOR version bump"
+                  # Check for new features (MINOR)
+                  elif echo "$COMMITS" | grep -qiE "^feat(\(.*\))?:"; then
+                    BUMP_TYPE="minor"
+                    echo "🟡 New feature detected → MINOR version bump"
+                  # Check for fixes or other changes (PATCH)
+                  elif echo "$COMMITS" | grep -qiE "^(fix|perf|refactor|docs|chore|style|test)(\(.*\))?:"; then
+                    BUMP_TYPE="patch"
+                    echo "🟢 Fix/improvement detected → PATCH version bump"
+                  else
+                    BUMP_TYPE="patch"
+                    echo "⚪ No conventional commits → default PATCH version bump"
+                  fi
+
+                  echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
+
+            - name: Calculate new version
+              id: calc_version
+              run: |
+                  CURRENT_VERSION="${{ steps.get_latest_tag.outputs.current_version }}"
+                  IS_FIRST_RELEASE="${{ steps.get_latest_tag.outputs.is_first_release }}"
+                  BUMP_TYPE="${{ github.event.inputs.version_bump || steps.analyze_commits.outputs.bump_type }}"
+                  PRERELEASE="${{ github.event.inputs.prerelease }}"
+
+                  echo "Current version: $CURRENT_VERSION"
+                  echo "First release: $IS_FIRST_RELEASE"
+                  echo "Bump type: $BUMP_TYPE"
+                  echo "Prerelease: $PRERELEASE"
+                  echo ""
+
+                  # Get current year
+                  CURRENT_YEAR=$(date +'%Y')
+
+                  if [ "$IS_FIRST_RELEASE" = "true" ]; then
+                    # This is the first CalVer release
+                    NEW_VERSION="$CURRENT_YEAR.0.0"
+                    echo "🎉 First CalVer release: $NEW_VERSION"
+                  else
+                    # Parse current version (format: YEAR.MAJOR.MINOR or YEAR.MAJOR.MINOR-alpha.X)
+                    # Remove any prerelease suffix first
+                    BASE_VERSION="${CURRENT_VERSION%%-*}"
+                    IFS='.' read -r YEAR MAJOR MINOR <<< "$BASE_VERSION"
+                    
+                    # If year changed, reset to YEAR.0.0
+                    if [ "$YEAR" != "$CURRENT_YEAR" ]; then
+                      NEW_VERSION="$CURRENT_YEAR.0.0"
+                      echo "📅 New year detected! Resetting to $NEW_VERSION"
+                    else
+                      # Apply version bump based on CalVer rules
+                      case $BUMP_TYPE in
+                        major)
+                          MAJOR=$((MAJOR + 1))
+                          MINOR=0
+                          echo "🔴 MAJOR bump: $CURRENT_VERSION → $CURRENT_YEAR.$MAJOR.$MINOR"
+                          ;;
+                        minor)
+                          MINOR=$((MINOR + 1))
+                          echo "🟡 MINOR bump: $CURRENT_VERSION → $CURRENT_YEAR.$MAJOR.$MINOR"
+                          ;;
+                        patch|auto)
+                          MINOR=$((MINOR + 1))
+                          echo "🟢 PATCH bump (increments MINOR in CalVer): $CURRENT_VERSION → $CURRENT_YEAR.$MAJOR.$MINOR"
+                          ;;
+                      esac
+                      
+                      # Build version string (with or without prerelease suffix)
+                      if [ "$PRERELEASE" = "true" ]; then
+                        NEW_VERSION="$CURRENT_YEAR.$MAJOR.$MINOR-alpha.$MINOR"
+                        echo "🔵 Prerelease version: $NEW_VERSION"
+                      else
+                        NEW_VERSION="$CURRENT_YEAR.$MAJOR.$MINOR"
+                        echo "✅ Stable version: $NEW_VERSION"
+                      fi
+                    fi
+                  fi
+
+                  BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+                  TAG_SUFFIX=""
+                  if [ "$BRANCH_NAME" = "main-stable-agent" ]; then
+                    TAG_SUFFIX="-agent"
+                  fi
+                  NEW_TAG="v$NEW_VERSION$TAG_SUFFIX"
+
+                  echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+                  echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+
+            - name: Check if version already exists
+              id: check_version
+              run: |
+                  NEW_TAG="${{ steps.calc_version.outputs.new_tag }}"
+
+                  if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
+                    echo "⚠️  Tag $NEW_TAG already exists!"
+                    echo "version_exists=true" >> $GITHUB_OUTPUT
+                  else
+                    echo "✅ Tag $NEW_TAG is available"
+                    echo "version_exists=false" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Update package.json version
+              if: steps.check_version.outputs.version_exists == 'false'
+              run: |
+                  NEW_VERSION="${{ steps.calc_version.outputs.new_version }}"
+                  echo "📝 Updating package.json to version $NEW_VERSION"
+
+                  # Get current package.json version
+                  CURRENT_PKG_VERSION=$(node -p "require('./src/package.json').version")
+                  echo "Current package.json version: $CURRENT_PKG_VERSION"
+
+                  # Update version in package.json (only if different)
+                  if [ "$CURRENT_PKG_VERSION" != "$NEW_VERSION" ]; then
+                    node -e "
+                      const fs = require('fs');
+                      const pkg = JSON.parse(fs.readFileSync('./src/package.json', 'utf8'));
+                      pkg.version = '$NEW_VERSION';
+                      fs.writeFileSync('./src/package.json', JSON.stringify(pkg, null, 2) + '\n');
+                    "
+                    echo "✅ package.json version updated to: $NEW_VERSION"
+                  else
+                    echo "ℹ️  package.json already at version $NEW_VERSION, skipping update"
+                  fi
+
+                  # Verify the changes
+                  PACKAGE_VERSION=$(node -p "require('./src/package.json').version")
+                  echo "✅ Final package.json version: $PACKAGE_VERSION"
+
+            - name: Commit version bump
+              if: steps.check_version.outputs.version_exists == 'false'
+              run: |
+                  NEW_VERSION="${{ steps.calc_version.outputs.new_version }}"
+
+                  # Check if there are any changes to commit
+                  if git diff --quiet src/package.json; then
+                    echo "ℹ️  No version changes detected, skipping commit"
+                  else
+                    # Configure git
+                    git config user.name "github-actions[bot]"
+                    git config user.email "github-actions[bot]@users.noreply.github.com"
+                    
+                    # Commit and push
+                    git add src/package.json
+                    git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
+                    git push
+                    
+                    echo "✅ Version changes committed and pushed to main branch"
+                  fi
+
+            - name: Install dependencies
+              if: steps.check_version.outputs.version_exists == 'false'
+              run: pnpm install --no-frozen-lockfile
+
+            - name: Run linting
+              if: steps.check_version.outputs.version_exists == 'false'
+              run: pnpm lint
+
+            - name: Run type checking
+              if: steps.check_version.outputs.version_exists == 'false'
+              run: pnpm check-types
+
+            - name: Build project
+              if: steps.check_version.outputs.version_exists == 'false'
+              run: pnpm build
+
+            - name: Check build output
+              if: steps.check_version.outputs.version_exists == 'false'
+              run: |
+                  echo "Build completed successfully!"
+                  if [ -d "out" ]; then
+                    echo "📁 Build output (out directory):"
+                    ls -la out/ | head -10
+                  fi
+                  if [ -d "dist" ]; then
+                    echo "📁 Build output (dist directory):"
+                    ls -la dist/ | head -10
+                  fi
+
+            - name: Create VSIX package
+              if: steps.check_version.outputs.version_exists == 'false'
+              run: pnpm vsix
+
+            - name: Find VSIX file
+              if: steps.check_version.outputs.version_exists == 'false'
+              id: find_vsix
+              run: |
+                  # Look for VSIX files in common locations
+                  VSIX_FILE=""
+                  if [ -d "bin" ] && [ "$(ls bin/*.vsix 2>/dev/null | wc -l)" -gt 0 ]; then
+                    VSIX_FILE=$(ls bin/*.vsix | head -1)
+                  elif [ "$(ls *.vsix 2>/dev/null | wc -l)" -gt 0 ]; then
+                    VSIX_FILE=$(ls *.vsix | head -1)
+                  fi
+
+                  if [ -n "$VSIX_FILE" ]; then
+                    echo "Found VSIX: $VSIX_FILE"
+                    echo "vsix_path=$VSIX_FILE" >> $GITHUB_OUTPUT
+                    echo "vsix_name=$(basename $VSIX_FILE)" >> $GITHUB_OUTPUT
+                  else
+                    echo "Error: No VSIX file found!"
+                    exit 1
+                  fi
+
+            - name: Generate checksums
+              if: steps.check_version.outputs.version_exists == 'false'
+              id: checksums
+              run: |
+                  VSIX_FILE="${{ steps.find_vsix.outputs.vsix_path }}"
+                  SHA256=$(sha256sum "$VSIX_FILE" | awk '{print $1}')
+                  echo "$SHA256" > "${VSIX_FILE}.sha256"
+                  echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+                  echo "✓ Checksum generated"
+                  echo "SHA256: $SHA256"
+
+            - name: Get build timestamp
+              id: timestamp
+              run: |
+                  echo "build_date=$(date +'%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_OUTPUT
+                  echo "build_date_compact=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
+
+            - name: Generate changelog
+              id: changelog
+              run: |
+                  LATEST_TAG="${{ steps.get_latest_tag.outputs.latest_tag }}"
+                  IS_FIRST_RELEASE="${{ steps.get_latest_tag.outputs.is_first_release }}"
+
+                  if [ "$IS_FIRST_RELEASE" = "true" ]; then
+                    echo "🎉 First CalVer release - showing recent commits"
+                    COMMITS=$(git log --pretty=format:"- %s by @%an in %h" --no-merges -20)
+                  else
+                    echo "📋 Generating changelog from $LATEST_TAG to HEAD"
+                    
+                    # Check if the tag actually exists in the repository
+                    if git rev-parse "$LATEST_TAG" >/dev/null 2>&1; then
+                      COMMITS=$(git log $LATEST_TAG..HEAD --pretty=format:"- %s by @%an in %h" --no-merges)
+                    else
+                      echo "⚠️  Tag $LATEST_TAG does not exist in repository"
+                      echo "📝 Showing recent commits (last 20)"
+                      COMMITS=$(git log --pretty=format:"- %s by @%an in %h" --no-merges -20)
+                    fi
+                  fi
+
+                  # Check if there are any commits
+                  if [ -z "$COMMITS" ]; then
+                    COMMITS="- No changes since last release"
+                  fi
+
+                  # Save to file
+                  echo "$COMMITS" > changelog.txt
+
+                  # Read into output
+                  CHANGELOG=$(cat changelog.txt)
+                  echo "changelog<<EOF" >> $GITHUB_OUTPUT
+                  echo "$CHANGELOG" >> $GITHUB_OUTPUT
+                  echo "EOF" >> $GITHUB_OUTPUT
+
+            - name: Get contributors
+              id: contributors
+              run: |
+                  LATEST_TAG="${{ steps.get_latest_tag.outputs.latest_tag }}"
+                  IS_FIRST_RELEASE="${{ steps.get_latest_tag.outputs.is_first_release }}"
+
+                  if [ "$IS_FIRST_RELEASE" = "true" ]; then
+                    CONTRIBUTORS=$(git log --pretty=format:"%an" --no-merges | sort -u | head -10 | sed 's/^/@/' | paste -sd ", " -)
+                  else
+                    if git rev-parse "$LATEST_TAG" >/dev/null 2>&1; then
+                      CONTRIBUTORS=$(git log $LATEST_TAG..HEAD --pretty=format:"%an" --no-merges | sort -u | sed 's/^/@/' | paste -sd ", " -)
+                    else
+                      CONTRIBUTORS=$(git log --pretty=format:"%an" --no-merges | sort -u | head -10 | sed 's/^/@/' | paste -sd ", " -)
+                    fi
+                  fi
+
+                  if [ -z "$CONTRIBUTORS" ]; then
+                    CONTRIBUTORS="@${{ github.actor }}"
+                  fi
+
+                  echo "contributors=$CONTRIBUTORS" >> $GITHUB_OUTPUT
+
+            - name: Get release quality
+              id: release_quality
+              run: |
+                  QUALITY=$(node -p "require('./src/package.json').releaseQuality || 'stable'")
+                  echo "quality=$QUALITY" >> $GITHUB_OUTPUT
+                  echo "Using release quality: $QUALITY"
+
+            - name: Create Release
+              if: steps.check_version.outputs.version_exists == 'false'
+              uses: softprops/action-gh-release@v1
+              with:
+                  name: "SIID Code Extension v${{ steps.calc_version.outputs.new_version }} (${{ steps.release_quality.outputs.quality }})"
+                  tag_name: ${{ steps.calc_version.outputs.new_tag }}
+                  draft: false
+                  prerelease: ${{ github.event.inputs.prerelease || 'false' }}
+                  generate_release_notes: false
+                  body: |
+                      ## SIID Code Extension Package
+
+                      **Build Date:** ${{ steps.timestamp.outputs.build_date }}
+                      **Version:** v${{ steps.calc_version.outputs.new_version }}
+                      **Version Bump:** ${{ steps.analyze_commits.outputs.bump_type }}
+                      **Release Quality:** ${{ steps.release_quality.outputs.quality }}
+
+                      ---
+
+                      ### 📦 Downloads
+
+                      | Package | Description |
+                      |---------|-------------|
+                      | **${{ steps.find_vsix.outputs.vsix_name }}** | VS Code Extension Package (install via Extensions view or `code --install-extension`) |
+
+                      ### 🔐 Checksums
+                      Use the .sha256 files to verify your download integrity.
+
+                      ---
+
+                      ### 📝 What's Changed
+
+                      ${{ steps.changelog.outputs.changelog }}
+
+                      **Full Changelog:** ${{ github.server_url }}/${{ github.repository }}/compare/${{ steps.get_latest_tag.outputs.latest_tag }}...${{ steps.calc_version.outputs.new_tag }}
+
+                      ---
+
+                      ### 👥 Contributors
+
+                      ${{ steps.contributors.outputs.contributors }}
+
+                      ---
+
+                      ### 📋 Version Information
+
+                      SIID Code follows **Calendar Versioning (CalVer)**: `YEAR.MAJOR.MINOR`
+                      - **YEAR**: Current year (e.g., 2025)
+                      - **MAJOR**: Breaking changes or significant new features
+                      - **MINOR**: New features (backward compatible) or bug fixes
+                      - Version resets at year boundary (e.g., 2025.x.x → 2026.0.0)
+                  files: |
+                      ${{ steps.find_vsix.outputs.vsix_path }}
+                      ${{ steps.find_vsix.outputs.vsix_path }}.sha256
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Upload Build Artifacts
+              if: steps.check_version.outputs.version_exists == 'false'
+              uses: actions/upload-artifact@v4
+              with:
+                  name: siid-code-extension-v${{ steps.calc_version.outputs.new_version }}-${{ steps.release_quality.outputs.quality }}
+                  path: |
+                      ${{ steps.find_vsix.outputs.vsix_path }}
+                      ${{ steps.find_vsix.outputs.vsix_path }}.sha256
+                  retention-days: 90
+
+            - name: Summary
+              if: always()
+              run: |
+                  echo "## 📊 Build Summary" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+                  echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+                  echo "| Previous Version | \`${{ steps.get_latest_tag.outputs.latest_tag }}\` |" >> $GITHUB_STEP_SUMMARY
+                  echo "| New Version | \`${{ steps.calc_version.outputs.new_tag }}\` |" >> $GITHUB_STEP_SUMMARY
+                  echo "| Bump Type | **${{ steps.analyze_commits.outputs.bump_type }}** |" >> $GITHUB_STEP_SUMMARY
+                  echo "| Build Date | ${{ steps.timestamp.outputs.build_date }} |" >> $GITHUB_STEP_SUMMARY
+                  echo "| Version Exists | ${{ steps.check_version.outputs.version_exists }} |" >> $GITHUB_STEP_SUMMARY
+                  echo "| Prerelease | ${{ github.event.inputs.prerelease || 'false' }} |" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+
+                  if [ "${{ steps.check_version.outputs.version_exists }}" == "true" ]; then
+                    echo "### ⚠️ Warning" >> $GITHUB_STEP_SUMMARY
+                    echo "Version ${{ steps.calc_version.outputs.new_tag }} already exists. Build was skipped." >> $GITHUB_STEP_SUMMARY
+                  else
+                    echo "### ✅ Success" >> $GITHUB_STEP_SUMMARY
+                    echo "Release ${{ steps.calc_version.outputs.new_tag }} created successfully!" >> $GITHUB_STEP_SUMMARY
+                  fi

--- a/apps/web-evals/package.json
+++ b/apps/web-evals/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"lint": "next lint --max-warnings 0",
 		"check-types": "tsc -b",
+		"test": "vitest run",
 		"dev": "scripts/check-services.sh && next dev",
 		"format": "prettier --write src",
 		"build": "next build",

--- a/src/core/prompts/__tests__/add-custom-instructions.spec.ts
+++ b/src/core/prompts/__tests__/add-custom-instructions.spec.ts
@@ -43,6 +43,18 @@ vi.mock("os-name", () => ({
 
 vi.mock("fs/promises")
 
+// getModesSection() mkdirs globalStorageUri.fsPath ("/mock/settings/path")
+// via `promises` from "fs", which vi.mock("fs/promises") does not intercept.
+// On Windows that lands in C:\mock and quietly succeeds; on Linux it is a
+// write to / and fails with EACCES.
+vi.mock("fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("fs")>()
+	return {
+		...actual,
+		promises: { ...actual.promises, mkdir: vi.fn().mockResolvedValue(undefined) },
+	}
+})
+
 import * as vscode from "vscode"
 
 import { ModeConfig } from "@siid-code/types"

--- a/src/core/prompts/__tests__/add-custom-instructions.spec.ts
+++ b/src/core/prompts/__tests__/add-custom-instructions.spec.ts
@@ -41,6 +41,13 @@ vi.mock("os-name", () => ({
 	default: () => "Linux",
 }))
 
+// getDeveloperInfoSection() puts process.platform and process.version straight
+// into the prompt, so the file snapshots below would otherwise record whichever
+// machine last regenerated them (win32/v22 locally, linux/v20 on CI) and fail
+// everywhere else. os-name and getShell are already pinned for the same reason.
+vi.spyOn(process, "platform", "get").mockReturnValue("win32")
+vi.spyOn(process, "version", "get").mockReturnValue("v22.19.0")
+
 vi.mock("fs/promises")
 
 // getModesSection() mkdirs globalStorageUri.fsPath ("/mock/settings/path")

--- a/src/core/prompts/__tests__/system-prompt.spec.ts
+++ b/src/core/prompts/__tests__/system-prompt.spec.ts
@@ -43,6 +43,18 @@ vi.mock("os-name", () => ({
 
 vi.mock("fs/promises")
 
+// getModesSection() mkdirs globalStorageUri.fsPath ("/mock/settings/path")
+// via `promises` from "fs", which vi.mock("fs/promises") does not intercept.
+// On Windows that lands in C:\mock and quietly succeeds; on Linux it is a
+// write to / and fails with EACCES.
+vi.mock("fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("fs")>()
+	return {
+		...actual,
+		promises: { ...actual.promises, mkdir: vi.fn().mockResolvedValue(undefined) },
+	}
+})
+
 import * as vscode from "vscode"
 
 import { ModeConfig } from "@siid-code/types"

--- a/src/core/prompts/__tests__/system-prompt.spec.ts
+++ b/src/core/prompts/__tests__/system-prompt.spec.ts
@@ -41,6 +41,13 @@ vi.mock("os-name", () => ({
 	default: () => "Linux",
 }))
 
+// getDeveloperInfoSection() puts process.platform and process.version straight
+// into the prompt, so the file snapshots below would otherwise record whichever
+// machine last regenerated them (win32/v22 locally, linux/v20 on CI) and fail
+// everywhere else. os-name and getShell are already pinned for the same reason.
+vi.spyOn(process, "platform", "get").mockReturnValue("win32")
+vi.spyOn(process, "version", "get").mockReturnValue("v22.19.0")
+
 vi.mock("fs/promises")
 
 // getModesSection() mkdirs globalStorageUri.fsPath ("/mock/settings/path")

--- a/src/core/prompts/sections/__tests__/custom-instructions.spec.ts
+++ b/src/core/prompts/sections/__tests__/custom-instructions.spec.ts
@@ -1150,7 +1150,11 @@ describe("Directory existence checks", () => {
 
 // Indirectly test readTextFilesFromDirectory and formatDirectoryContent through loadRuleFiles
 describe("Rules directory reading", () => {
-	it.skipIf(process.platform === "win32")("should follow symbolic links in the rules directory", async () => {
+	// TODO: rewrite for b2c030206 — that commit removed project-level .roo
+	// scanning, so loadRuleFiles() no longer reads cwd/.roo/rules and returns ""
+	// unless a bundled rules dir exists in global storage. This test mocks the
+	// old cwd path. It was skipIf(win32), so it only ever ran on Linux/CI.
+	it.skip("should follow symbolic links in the rules directory", async () => {
 		// Simulate .roo/rules directory exists
 		statMock.mockResolvedValueOnce({
 			isDirectory: vi.fn().mockReturnValue(true),
@@ -1285,7 +1289,9 @@ describe("Rules directory reading", () => {
 		vi.clearAllMocks()
 	})
 
-	it.skipIf(process.platform === "win32")("should correctly format multiple files from directory", async () => {
+	// TODO: rewrite for b2c030206 — see the note on the symlink test above.
+	// loadRuleFiles() no longer reads cwd/.roo/rules, so result is always "".
+	it.skip("should correctly format multiple files from directory", async () => {
 		// Simulate .roo/rules directory exists
 		statMock.mockResolvedValueOnce({
 			isDirectory: vi.fn().mockReturnValue(true),

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -31,6 +31,18 @@ vi.mock("execa", () => ({
 	execa: vi.fn(),
 }))
 
+// getModesSection() mkdirs globalStorageUri.fsPath ("/test/storage") via
+// `promises` from "fs", which the fs/promises mock below does not intercept.
+// On Windows that lands in C:\test and quietly succeeds; on Linux it is a
+// write to / and fails with EACCES.
+vi.mock("fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("fs")>()
+	return {
+		...actual,
+		promises: { ...actual.promises, mkdir: vi.fn().mockResolvedValue(undefined) },
+	}
+})
+
 vi.mock("fs/promises", async (importOriginal) => {
 	const actual = (await importOriginal()) as Record<string, any>
 	const mockFunctions = {

--- a/webview-ui/vitest.setup.ts
+++ b/webview-ui/vitest.setup.ts
@@ -1,5 +1,12 @@
 import "@testing-library/jest-dom"
 import "@testing-library/jest-dom/vitest"
+import { configure } from "@testing-library/react"
+
+// waitFor's 1s default is enough when this suite runs alone, but `pnpm test`
+// runs it in parallel with the src suite and the async auto-approval
+// assertions in ChatView can miss that window on a loaded machine. Costs
+// nothing when the assertion passes — waitFor returns as soon as it does.
+configure({ asyncUtilTimeout: 5000 })
 
 // Force React into development mode for tests
 // This is needed to enable act(...) function in React Testing Library


### PR DESCRIPTION
`main-stable-agent` counterpart of #198 (green). Clean cherry-pick of all three commits, re-verified on this base.

**CI has never run tests.** The `pr-checks` job runs lint, check-types, format and build — no test step. That is how the `src` and `webview-ui` suites drifted to 263 and 83 failures unnoticed.

## The three commits

**1. `ci: run tests on PRs`** — adds `pnpm test` to `pr-checks`, fanning out through turbo to every package with a `test` script. Also wires up `apps/web-evals` (a passing 8-test suite that had no `test` script, so turbo never ran it) and raises webview-ui's `asyncUtilTimeout` to 5s, which fixes 3 ChatView auto-approve tests that flaked when turbo runs both suites in parallel on a loaded machine.

**2. `fix(tests): mock bare "fs"`** — 18 Linux-only failures. `getModesSection()` mkdirs `globalStorageUri.fsPath` importing `promises` from `"fs"`, while these specs mock `"fs/promises"` — a different specifier, so a real mkdir ran. On Windows `/mock/settings/path` and `/test/storage` become `C:\mock` and `C:\test` and quietly succeed; on Linux they are writes to `/` and fail with EACCES.

**3. `fix(tests): pin env values, skip two stale rules tests`** — the remaining 15.

- **13 snapshot failures**: `getDeveloperInfoSection()` interpolates `process.platform` and `process.version` into the prompt, so the committed `.snap` files carry whichever machine last regenerated them (`win32`/`v22.19.0` locally vs `linux`/`v20.19.2` on CI). Every one of the 13 diffs was *only* those two lines. Pinned with `spyOn` getters, matching the existing `os-name`/`getShell` mocks that pin the same section for the same reason. **Regenerating would have been the wrong fix** — it would move the breakage from CI to every developer's machine.
- **2 rules-directory failures**: `b2c030206` removed project-level `.roo` scanning, so `loadRuleFiles()` no longer reads `cwd/.roo/rules`. Both tests mock the old path. They were `it.skipIf(win32)`, so they only ever ran on Linux — CI was the first place they executed at all. Skipped with `TODO: rewrite for b2c030206`, not deleted.

This base carries the identical `win32`/`v22.19.0` fingerprints in all 13 snapshots, so it had the same latent failures.

## Verification on this base

Re-run here rather than inherited from the cherry-pick:

- **`pnpm test` (full workspace): 7/7 tasks.** src 3442 passed / 142 skipped across 269 files; webview-ui 917 passed / 22 skipped across 80 files.
- `npx tsc --noEmit` — clean
- prettier + eslint via pre-commit hook — clean

One transient `EBUSY: resource busy or locked` appeared in `error-capture.spec.ts` on an intermediate Windows run (that spec writes real temp files). It passed in isolation and on the full re-run — a local filesystem artifact, not a code defect, and not reachable on ubuntu CI.

## Note on scope

The gate covers **pull requests only** (`pr-checks` is gated on `if: github.event_name == 'pull_request'`). A direct push to `main-stable-agent` still runs the release job without tests. Left out to keep this minimal — worth deciding separately.