### PR TITLE
fix(ci): prevent duplicate versions across concurrent release runs

### DIFF
--- a/.github/workflows/build-auto-version.yml
+++ b/.github/workflows/build-auto-version.yml
@@ -147,6 +147,12 @@ jobs:
         runs-on: ubuntu-latest
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-stable-agent')
 
+        # Serialize releases per branch: a second push waits instead of racing
+        # the first for the same version number.
+        concurrency:
+            group: release-${{ github.ref }}
+            cancel-in-progress: false
+
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
@@ -170,8 +176,16 @@ jobs:
               run: |
                   echo "🔍 Searching for latest CalVer tag (YEAR.MAJOR.MINOR format)..."
 
-                  # Get all v*.*.* tags
-                  ALL_TAGS=$(git tag -l "v*.*.*")
+                  # Refetch tags: another run may have released while this one queued.
+                  git fetch --tags --force origin
+
+                  BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+                  if [ "$BRANCH_NAME" = "main-stable-agent" ]; then
+                    # main-stable-agent owns the -agent suffix; main owns bare tags.
+                    ALL_TAGS=$(git tag -l "v*.*.*-agent")
+                  else
+                    ALL_TAGS=$(git tag -l "v*.*.*" | grep -v -- '-agent$')
+                  fi
 
                   # Filter to ONLY CalVer versions (YEAR >= 2000)
                   LATEST_TAG=$(echo "$ALL_TAGS" | while read tag; do
@@ -332,23 +346,63 @@ jobs:
                   echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
                   echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
 
-            - name: Check if version already exists
+            - name: Reserve version tag
               id: check_version
               run: |
+                  # Claim the version NOW, before the long build, by pushing the tag.
+                  # `git push` of a new ref is atomic: if a concurrent run already
+                  # took this number the push is rejected and we try the next one.
+                  # This is what makes two overlapping runs land on different
+                  # versions even if the concurrency queue is bypassed.
+                  NEW_VERSION="${{ steps.calc_version.outputs.new_version }}"
                   NEW_TAG="${{ steps.calc_version.outputs.new_tag }}"
 
-                  if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
-                    echo "⚠️  Tag $NEW_TAG already exists!"
-                    echo "version_exists=true" >> $GITHUB_OUTPUT
-                  else
-                    echo "✅ Tag $NEW_TAG is available"
-                    echo "version_exists=false" >> $GITHUB_OUTPUT
+                  BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+                  TAG_SUFFIX=""
+                  if [ "$BRANCH_NAME" = "main-stable-agent" ]; then
+                    TAG_SUFFIX="-agent"
                   fi
+
+                  IFS='.' read -r YEAR MAJOR MINOR <<< "${NEW_VERSION%%-*}"
+
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+                  for attempt in $(seq 1 20); do
+                    # Push an ANNOTATED tag: it carries a unique object, so if the
+                    # tag name is taken the push is rejected even when the other
+                    # run tagged this same commit (a lightweight tag would be
+                    # silently accepted as "Everything up-to-date").
+                    git tag -f -a "$NEW_TAG-local" -m "Release $NEW_TAG" HEAD
+                    PUSH_ERR=$(git push origin "$NEW_TAG-local:refs/tags/$NEW_TAG" 2>&1) && {
+                      echo "✅ Reserved $NEW_TAG"
+                      echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+                      echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+                      echo "version_exists=false" >> $GITHUB_OUTPUT
+                      exit 0
+                    }
+
+                    # Only a stale-info/rejection means "taken"; anything else
+                    # (auth, network) is a real error worth failing on.
+                    if ! echo "$PUSH_ERR" | grep -qE 'stale info|already exists|\[rejected\]'; then
+                      echo "❌ Tag push failed for a non-collision reason:"
+                      echo "$PUSH_ERR"
+                      exit 1
+                    fi
+
+                    MINOR=$((MINOR + 1))
+                    NEW_VERSION="$YEAR.$MAJOR.$MINOR"
+                    NEW_TAG="v$NEW_VERSION$TAG_SUFFIX"
+                    echo "↻ Taken, retrying with $NEW_TAG"
+                  done
+
+                  echo "❌ Could not reserve a version after 20 attempts"
+                  exit 1
 
             - name: Update package.json version
               if: steps.check_version.outputs.version_exists == 'false'
               run: |
-                  NEW_VERSION="${{ steps.calc_version.outputs.new_version }}"
+                  NEW_VERSION="${{ steps.check_version.outputs.new_version }}"
                   echo "📝 Updating package.json to version $NEW_VERSION"
 
                   # Get current package.json version
@@ -375,7 +429,7 @@ jobs:
             - name: Commit version bump
               if: steps.check_version.outputs.version_exists == 'false'
               run: |
-                  NEW_VERSION="${{ steps.calc_version.outputs.new_version }}"
+                  NEW_VERSION="${{ steps.check_version.outputs.new_version }}"
 
                   # Check if there are any changes to commit
                   if git diff --quiet src/package.json; then
@@ -388,8 +442,9 @@ jobs:
                     # Commit and push
                     git add src/package.json
                     git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
+                    git pull --rebase origin "${GITHUB_REF#refs/heads/}"
                     git push
-                    
+
                     echo "✅ Version changes committed and pushed to main branch"
                   fi
 
@@ -533,8 +588,8 @@ jobs:
               if: steps.check_version.outputs.version_exists == 'false'
               uses: softprops/action-gh-release@v1
               with:
-                  name: "SIID Code Extension v${{ steps.calc_version.outputs.new_version }} (${{ steps.release_quality.outputs.quality }})"
-                  tag_name: ${{ steps.calc_version.outputs.new_tag }}
+                  name: "SIID Code Extension v${{ steps.check_version.outputs.new_version }} (${{ steps.release_quality.outputs.quality }})"
+                  tag_name: ${{ steps.check_version.outputs.new_tag }}
                   draft: false
                   prerelease: ${{ github.event.inputs.prerelease || 'false' }}
                   generate_release_notes: false
@@ -542,7 +597,7 @@ jobs:
                       ## SIID Code Extension Package
 
                       **Build Date:** ${{ steps.timestamp.outputs.build_date }}
-                      **Version:** v${{ steps.calc_version.outputs.new_version }}
+                      **Version:** v${{ steps.check_version.outputs.new_version }}
                       **Version Bump:** ${{ steps.analyze_commits.outputs.bump_type }}
                       **Release Quality:** ${{ steps.release_quality.outputs.quality }}
 
@@ -563,7 +618,7 @@ jobs:
 
                       ${{ steps.changelog.outputs.changelog }}
 
-                      **Full Changelog:** ${{ github.server_url }}/${{ github.repository }}/compare/${{ steps.get_latest_tag.outputs.latest_tag }}...${{ steps.calc_version.outputs.new_tag }}
+                      **Full Changelog:** ${{ github.server_url }}/${{ github.repository }}/compare/${{ steps.get_latest_tag.outputs.latest_tag }}...${{ steps.check_version.outputs.new_tag }}
 
                       ---
 
@@ -590,11 +645,34 @@ jobs:
               if: steps.check_version.outputs.version_exists == 'false'
               uses: actions/upload-artifact@v4
               with:
-                  name: siid-code-extension-v${{ steps.calc_version.outputs.new_version }}-${{ steps.release_quality.outputs.quality }}
+                  name: siid-code-extension-v${{ steps.check_version.outputs.new_version }}-${{ steps.release_quality.outputs.quality }}
                   path: |
                       ${{ steps.find_vsix.outputs.vsix_path }}
                       ${{ steps.find_vsix.outputs.vsix_path }}.sha256
                   retention-days: 90
+
+            - name: Release reserved tag on failure
+              # The tag is pushed early to claim the version, so a failed build
+              # would otherwise leave an orphan tag and burn that number forever.
+              # Delete it on failure/cancellation so the version is reusable.
+              if: failure() || cancelled()
+              run: |
+                  NEW_TAG="${{ steps.check_version.outputs.new_tag }}"
+                  if [ -z "$NEW_TAG" ]; then
+                    echo "No tag was reserved; nothing to clean up."
+                    exit 0
+                  fi
+
+                  # Only remove it if no release was published against it.
+                  if gh release view "$NEW_TAG" >/dev/null 2>&1; then
+                    echo "⚠️  Release exists for $NEW_TAG — keeping the tag."
+                    exit 0
+                  fi
+
+                  echo "🧹 Build failed — releasing reserved version $NEW_TAG"
+                  git push origin ":refs/tags/$NEW_TAG" || echo "Tag already gone."
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Summary
               if: always()
@@ -604,7 +682,7 @@ jobs:
                   echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
                   echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
                   echo "| Previous Version | \`${{ steps.get_latest_tag.outputs.latest_tag }}\` |" >> $GITHUB_STEP_SUMMARY
-                  echo "| New Version | \`${{ steps.calc_version.outputs.new_tag }}\` |" >> $GITHUB_STEP_SUMMARY
+                  echo "| New Version | \`${{ steps.check_version.outputs.new_tag }}\` |" >> $GITHUB_STEP_SUMMARY
                   echo "| Bump Type | **${{ steps.analyze_commits.outputs.bump_type }}** |" >> $GITHUB_STEP_SUMMARY
                   echo "| Build Date | ${{ steps.timestamp.outputs.build_date }} |" >> $GITHUB_STEP_SUMMARY
                   echo "| Version Exists | ${{ steps.check_version.outputs.version_exists }} |" >> $GITHUB_STEP_SUMMARY
@@ -613,8 +691,8 @@ jobs:
 
                   if [ "${{ steps.check_version.outputs.version_exists }}" == "true" ]; then
                     echo "### ⚠️ Warning" >> $GITHUB_STEP_SUMMARY
-                    echo "Version ${{ steps.calc_version.outputs.new_tag }} already exists. Build was skipped." >> $GITHUB_STEP_SUMMARY
+                    echo "Version ${{ steps.check_version.outputs.new_tag }} already exists. Build was skipped." >> $GITHUB_STEP_SUMMARY
                   else
                     echo "### ✅ Success" >> $GITHUB_STEP_SUMMARY
-                    echo "Release ${{ steps.calc_version.outputs.new_tag }} created successfully!" >> $GITHUB_STEP_SUMMARY
+                    echo "Release ${{ steps.check_version.outputs.new_tag }} created successfully!" >> $GITHUB_STEP_SUMMARY
                   fi


### PR DESCRIPTION
## Problem

Two release runs on the same branch could pick the **same version number**.

The version was chosen early in the job but only published as a tag at `Create Release` — after install, lint, typecheck, build and VSIX packaging. For that whole multi-minute window the chosen number was invisible to every other run:

```
A: read .57 → pick .58 → [build ~5min] → tag .58 ✋
B: read .57 → pick .58 → [build ~5min] → tag .58 ✋ collision
   └──────────── .58 invisible to B this whole time ────────────┘
```

A second, separate cause: the tag scan stripped the `-agent` suffix before comparing, so `main` and `main-stable-agent` drew from one shared counter. That produced the existing `v2026.0.56` / `v2026.0.56-agent` pair.

## Fix

Claim the version **before** the build instead of after, by pushing its tag and retrying the next number if the push is rejected:

```
A: read .57 → push tag .58 → wins     → [build] → release .58
B: read .57 → push tag .58 → REJECTED
            → push tag .59 → wins     → [build] → release .59
```

Creating a ref on a remote is atomic — git accepts it only if it doesn't already exist, inside the remote's ref transaction — so two simultaneous pushes cannot both succeed. This is a genuine compare-and-swap and does not rely on run ordering.

### Details worth reviewing

- **Annotated tag, not lightweight.** A lightweight tag push where the tag exists *and points at the same commit* returns `Everything up-to-date` with **exit 0** — two runs on one merge commit would both believe they had reserved it. An annotated tag carries a unique object, so it always gets a real `[rejected] (already exists)`. (`--force-with-lease` does **not** help here; git short-circuits before the lease check.)
- **Orphan-tag cleanup.** Reserving early means a failed build would strand a public tag and burn that number forever. A cleanup step (`if: failure() || cancelled()`) deletes the reserved tag, guarded by `gh release view` so a tag with a real release attached is never removed.
- **Per-branch tag scan**, so `main` and `main-stable-agent` no longer share a counter. This branch reads only `*-agent` tags.
- **`concurrency` group** as defence in depth. It is not the mechanism — GitHub holds only one pending run per group, so a third rapid merge would evict the second and *skip* a version. Correctness comes from the atomic reservation.
- **Fail loudly on real errors.** The previous code sent push errors to `/dev/null`, so an auth or network failure was indistinguishable from a taken version. Non-collision errors now fail the step. A genuine collision also fails instead of silently skipping every downstream step and reporting green.
- **Rebase before pushing** the version-bump commit, which previously used a bare `git push` that fails if another run pushed first.

## Verification

Five concurrent runs racing against one remote, all starting from the same version:

```
run1 → v2026.0.58   run2 → v2026.0.59   run4 → v2026.0.60
run5 → v2026.0.61   run3 → v2026.0.62
```

Distinct, consecutive, no duplicates and no gaps. Also verified: the retry correctly skips numbers already taken **on the same commit** (the case that defeats a lightweight tag), and that cleanup frees a number for reuse by a later run.

## Failure behaviour

The failing run releases its number, succeeding runs keep theirs, no gaps. One caveat: if a runner dies hard (infra kill, force-cancel past the grace period) cleanup cannot run and an orphan tag remains — harmless apart from skipping one version, and the retry loop handles the tag being present.

## Notes

- Paired with #201, the identical change for `main`. The workflow file is currently identical on both branches. **Both should be merged**, otherwise whichever branch lacks the fix keeps writing into the shared counter.
- The repo has 47 leftover `vundefined-*` tags from an older workflow. They are correctly ignored by the version parser and are untouched here — happy to clean them up separately.
