### PR TITLE
fix(tests): stub createTextEditorDecorationType so 3 webview suites can load

### DIFF
--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -148,6 +148,9 @@ vi.mock("vscode", () => ({
 		showWarningMessage: vi.fn(),
 		showErrorMessage: vi.fn(),
 		onDidChangeActiveTextEditor: vi.fn(() => ({ dispose: vi.fn() })),
+		// Called at module scope by DecorationController, which this suite pulls in
+		// transitively via checkpoints -> DiffViewProvider.
+		createTextEditorDecorationType: vi.fn(() => ({ dispose: vi.fn() })),
 	},
 	workspace: {
 		getConfiguration: vi.fn().mockReturnValue({

--- a/src/core/webview/__tests__/ClineProvider.sticky-mode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.sticky-mode.spec.ts
@@ -28,6 +28,9 @@ vi.mock("vscode", () => ({
 		showWarningMessage: vi.fn(),
 		showErrorMessage: vi.fn(),
 		onDidChangeActiveTextEditor: vi.fn(() => ({ dispose: vi.fn() })),
+		// Called at module scope by DecorationController, which this suite pulls in
+		// transitively via checkpoints -> DiffViewProvider.
+		createTextEditorDecorationType: vi.fn(() => ({ dispose: vi.fn() })),
 	},
 	workspace: {
 		getConfiguration: vi.fn().mockReturnValue({

--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -44,6 +44,9 @@ vi.mock("vscode", () => ({
 	window: {
 		showInformationMessage: vi.fn(),
 		showErrorMessage: vi.fn(),
+		// Called at module scope by DecorationController, which this suite pulls in
+		// transitively via checkpoints -> DiffViewProvider.
+		createTextEditorDecorationType: vi.fn(() => ({ dispose: vi.fn() })),
 	},
 	workspace: {
 		workspaceFolders: [{ uri: { fsPath: "/mock/workspace" } }],


### PR DESCRIPTION
Pre-existing breakage on `main` — surfaced by CI on #187, but not caused by it (reproduces on a clean main checkout).

### What was failing
Three suites failed at *collection*, so none of their tests ran:
- `core/webview/__tests__/ClineProvider.spec.ts`
- `core/webview/__tests__/ClineProvider.sticky-mode.spec.ts`
- `core/webview/__tests__/webviewMessageHandler.spec.ts`

```
TypeError: window.createTextEditorDecorationType is not a function
 ❯ integrations/editor/DecorationController.ts:3:50
 ❯ integrations/editor/DiffViewProvider.ts:17:1
 ❯ core/checkpoints/index.ts:16:1
 ❯ core/webview/webviewMessageHandler.ts:59:1
```

### Why
`core/checkpoints/index.ts` imports `DIFF_VIEW_URI_SCHEME` — a plain string constant — from `DiffViewProvider`. Loading that module executes `DecorationController.ts`, which calls `vscode.window.createTextEditorDecorationType(...)` at module scope. None of the three `vi.mock("vscode")` factories defined it, so the import chain threw before any test executed.

### Fix
Stub it in each mock's `window`. Three lines of actual change.

### Result
Full `src` suite: **264 files passed, 0 failed** (was 3 failed / 260 passed). Test count 3313 → 3444 — the +131 are the tests these suites were silently never running.

### Follow-up worth considering
The structural fix is to move `DIFF_VIEW_URI_SCHEME` into its own constants module so `checkpoints` stops dragging in decoration code for one string. Left out here to keep this diff minimal and unblock CI.