### PR TITLE
feat: model selector fetches models from custom OpenAI-compatible endpoints

### DIFF
--- a/packages/types/src/vscode.ts
+++ b/packages/types/src/vscode.ts
@@ -57,6 +57,9 @@ export const commandIds = [
 	"onFirebaseLogout",
 
 	"testOpenRouterApiKey",
+
+	"addCustomProvider",
+	"switchModel",
 ] as const
 
 export type CommandId = (typeof commandIds)[number]

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -16,6 +16,7 @@ import { CodeIndexManager } from "../services/code-index/manager"
 import { importSettingsWithFeedback } from "../core/config/importExport"
 import { MdmService } from "../services/mdm/MdmService"
 import { t } from "../i18n"
+import { getOpenAiModels } from "../api/providers/openai"
 
 /**
  * Helper to get the visible ClineProvider instance or log if not found.
@@ -377,6 +378,93 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 				`Failed to create OpenRouter API key: ${error instanceof Error ? error.message : String(error)}`,
 			)
 		}
+	},
+	addCustomProvider: async () => {
+		const visibleProvider = getVisibleProviderOrLog(outputChannel)
+		if (!visibleProvider) {
+			return
+		}
+
+		const name = await vscode.window.showInputBox({
+			prompt: "Profile name (e.g. 9router, omniroute)",
+			ignoreFocusOut: true,
+			validateInput: (v) => (v.trim() ? undefined : "Name required"),
+		})
+		if (!name) return
+
+		const baseUrl = await vscode.window.showInputBox({
+			prompt: "OpenAI-compatible endpoint (base URL, without /models)",
+			placeHolder: "https://api.9router.ai/v1",
+			ignoreFocusOut: true,
+			validateInput: (v) => (URL.canParse(v.trim()) ? undefined : "Invalid URL"),
+		})
+		if (!baseUrl) return
+
+		const apiKey = await vscode.window.showInputBox({
+			prompt: "API key",
+			password: true,
+			ignoreFocusOut: true,
+			validateInput: (v) => (v.trim() ? undefined : "API key required"),
+		})
+		if (!apiKey) return
+
+		const trimmedUrl = baseUrl.trim()
+		const models = await vscode.window.withProgress(
+			{ location: vscode.ProgressLocation.Notification, title: "Fetching models…" },
+			() => getOpenAiModels(trimmedUrl, apiKey.trim()),
+		)
+
+		let modelId: string | undefined
+		if (models.length > 0) {
+			modelId = await vscode.window.showQuickPick([...models, "$(edit) Enter manually…"], {
+				placeHolder: "Select model",
+				ignoreFocusOut: true,
+			})
+			if (modelId === "$(edit) Enter manually…") modelId = undefined
+			else if (!modelId) return
+		}
+		if (!modelId) {
+			modelId = await vscode.window.showInputBox({
+				prompt: "Model ID",
+				ignoreFocusOut: true,
+				validateInput: (v) => (v.trim() ? undefined : "Model ID required"),
+			})
+			if (!modelId) return
+		}
+
+		await visibleProvider.upsertProviderProfile(name.trim(), {
+			apiProvider: "openai",
+			openAiBaseUrl: trimmedUrl,
+			openAiApiKey: apiKey.trim(),
+			openAiModelId: modelId.trim(),
+		})
+		vscode.window.showInformationMessage(`Custom provider "${name.trim()}" saved and activated.`)
+	},
+	switchModel: async () => {
+		const visibleProvider = getVisibleProviderOrLog(outputChannel)
+		if (!visibleProvider) {
+			return
+		}
+
+		const profiles = await visibleProvider.providerSettingsManager.listConfig()
+		if (profiles.length === 0) {
+			vscode.window.showWarningMessage("No provider profiles found.")
+			return
+		}
+
+		const current = visibleProvider.contextProxy.getValue("currentApiConfigName") as string | undefined
+		const picked = await vscode.window.showQuickPick(
+			profiles.map((p) => ({
+				label: p.name === current ? `$(check) ${p.name}` : p.name,
+				description: p.apiProvider,
+				profileName: p.name,
+			})),
+			{ placeHolder: "Switch model / provider profile", ignoreFocusOut: true },
+		)
+		if (!picked) return
+
+		await visibleProvider.activateProviderProfile({ name: picked.profileName })
+		vscode.window.showInformationMessage(`Switched to "${picked.profileName}".`)
 	},
 	openChatView: async () => {
 		// Open the sidebar view first

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -796,7 +796,7 @@ export const webviewMessageHandler = async (
 			break
 		}
 		case "requestOpenAiModels":
-			if (message?.values?.baseUrl && message?.values?.apiKey) {
+			if (message?.values?.baseUrl) {
 				const openAiModels = await getOpenAiModels(
 					message?.values?.baseUrl,
 					message?.values?.apiKey,

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -948,6 +948,12 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 								title={t("chat:selectModel", { defaultValue: "Select model" })}
 								useFreeModels={useFreeModels}
 								developerMode={developerMode}
+								customProvider={{
+									apiProvider: apiConfiguration?.apiProvider,
+									openAiBaseUrl: apiConfiguration?.openAiBaseUrl,
+									openAiApiKey: apiConfiguration?.openAiApiKey,
+									openAiHeaders: apiConfiguration?.openAiHeaders,
+								}}
 							/>
 						</div>
 					)}

--- a/webview-ui/src/components/chat/ModelSelector.tsx
+++ b/webview-ui/src/components/chat/ModelSelector.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { useEvent } from "react-use"
 import { Check } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useRooPortal } from "@/components/ui/hooks/useRooPortal"
@@ -6,6 +7,15 @@ import { Popover, PopoverContent, PopoverTrigger, StandardTooltip } from "@/comp
 import { useAppTranslation } from "@/i18n/TranslationContext"
 import { getModelsForMode } from "@roo/mode-models"
 import { Mode } from "@roo/modes"
+import { vscode } from "@/utils/vscode"
+import { ExtensionMessage } from "@roo/ExtensionMessage"
+
+type CustomProviderInfo = {
+	apiProvider?: string
+	openAiBaseUrl?: string
+	openAiApiKey?: string
+	openAiHeaders?: Record<string, string>
+}
 
 interface ModelSelectorProps {
 	value: string // Current model ID
@@ -16,6 +26,7 @@ interface ModelSelectorProps {
 	triggerClassName?: string
 	useFreeModels?: boolean // Filter to show only free models
 	developerMode?: boolean // Developer mode shows all models
+	customProvider?: CustomProviderInfo // When apiProvider is a custom endpoint (openai), fetch models from it
 }
 
 export const ModelSelector = ({
@@ -27,8 +38,10 @@ export const ModelSelector = ({
 	triggerClassName = "",
 	useFreeModels = false,
 	developerMode = false,
+	customProvider,
 }: ModelSelectorProps) => {
 	const [open, setOpen] = React.useState(false)
+	const [customModels, setCustomModels] = React.useState<string[] | null>(null)
 	const portalContainer = useRooPortal("roo-portal")
 	const { t } = useAppTranslation()
 	const formatTierLabel = React.useCallback((tier: string) => {
@@ -36,8 +49,41 @@ export const ModelSelector = ({
 		return tier.charAt(0).toUpperCase() + tier.slice(1)
 	}, [])
 
+	const isCustomEndpoint = customProvider?.apiProvider === "openai" && !!customProvider.openAiBaseUrl
+
+	// Fetch models from the custom endpoint when the popover opens
+	React.useEffect(() => {
+		if (!open || !isCustomEndpoint) return
+		vscode.postMessage({
+			type: "requestOpenAiModels",
+			values: {
+				baseUrl: customProvider!.openAiBaseUrl,
+				apiKey: customProvider!.openAiApiKey,
+				openAiHeaders: customProvider!.openAiHeaders,
+			},
+		})
+	}, [open, isCustomEndpoint, customProvider])
+
+	const onMessage = React.useCallback(
+		(event: MessageEvent) => {
+			if (!isCustomEndpoint) return
+			const message: ExtensionMessage = event.data
+			if (message.type === "openAiModels") {
+				setCustomModels(message.openAiModels ?? [])
+			}
+		},
+		[isCustomEndpoint],
+	)
+	useEvent("message", onMessage)
+
 	// Get available models for the current mode with filtering
 	const availableModels = React.useMemo(() => {
+		// Custom endpoint (9Router/OmniRoute): show the endpoint's model list
+		if (isCustomEndpoint) {
+			const ids = customModels ?? (value ? [value] : [])
+			return ids.map((id) => ({ modelId: id, displayName: id, tier: "" as string, priority: 999 }))
+		}
+
 		const allModels = getModelsForMode(mode)
 
 		// Developer mode shows all models
@@ -58,7 +104,7 @@ export const ModelSelector = ({
 
 		// Sort by priority (lower number = higher priority)
 		return [...filtered].sort((a, b) => (a.priority || 999) - (b.priority || 999))
-	}, [mode, useFreeModels, developerMode])
+	}, [mode, useFreeModels, developerMode, isCustomEndpoint, customModels, value])
 
 	// Find the selected model info
 	const selectedModel = React.useMemo(() => {

--- a/webview-ui/src/components/settings/constants.ts
+++ b/webview-ui/src/components/settings/constants.ts
@@ -50,7 +50,7 @@ export const PROVIDERS = [
 	{ value: "deepseek", label: "DeepSeek" },
 	{ value: "moonshot", label: "Moonshot" },
 	{ value: "openai-native", label: "OpenAI" },
-	{ value: "openai", label: "OpenAI Compatible" },
+	{ value: "openai", label: "9Router / OmniRoute" },
 	{ value: "vertex", label: "GCP Vertex AI" },
 	{ value: "bedrock", label: "Amazon Bedrock" },
 	{ value: "glama", label: "Glama" },


### PR DESCRIPTION
## Summary
- Wires ChatTextArea's ModelSelector to the configured OpenAI-compatible provider (9Router/OmniRoute) so it lists models fetched from the endpoint instead of the built-in mode-model list.
- Drops the `apiKey` requirement in the `requestOpenAiModels` handler so endpoints that don't require a key still return a model list.